### PR TITLE
Replace all '//' comments with '/* */ comments.

### DIFF
--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/Statemachine.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/Statemachine.xtend
@@ -105,7 +105,7 @@ class Statemachine {
 	'''
 
 	def statesEnumDecl(ExecutionFlow it) '''
-		//! enumeration of all states 
+		/*! Enumeration of all states */ 
 		typedef enum {
 			«FOR state : states »
 			«state.shortName»,
@@ -132,14 +132,14 @@ class Statemachine {
 	
 	
 	def scopeTypeDecl(Scope it) '''
-		//! Type definition of the data structure for the «type» interface scope.
+		/*! Type definition of the data structure for the «type» interface scope. */
 		typedef struct {
 			«FOR d : declarations »
 			«d.structDeclaration»
 			«ENDFOR»
 		} «it.type»;
 		
-		//declaration of constants for scope «type»
+		/* Declaration of constants for scope «type». */
 		«FOR d : declarations.filter(typeof(VariableDefinition)).filter[const]»
 			«IF d.type.name != 'void'»const «d.type.targetLanguageName» «d.constantName» = «d.initialValue.resolveConstants»;«ENDIF»
 		«ENDFOR»
@@ -147,14 +147,16 @@ class Statemachine {
 	'''
 
 	def statemachineTypeDecl(ExecutionFlow it) '''
-		//! the maximum number of orthogonal states defines the dimension of the state configuration vector.
+		/*! Define dimension of the state configuration vector for orthogonal states. */
 		#define «type.toUpperCase»_MAX_ORTHOGONAL_STATES «stateVector.size»
 		«IF hasHistory»
-		//! dimension of the state configuration vector for history states
+		/*! Define dimension of the state configuration vector for history states. */
 		#define «type.toUpperCase»_MAX_HISTORY_STATES «historyVector.size»«ENDIF»
 		
-		/*! Type definition of the data structure for the «type» state machine.
-		This data structure has to be allocated by the client code. */
+		/*! 
+		 * Type definition of the data structure for the «type» state machine.
+		 * This data structure has to be allocated by the client code. 
+		 */
 		typedef struct {
 			«statesEnumType» stateConfVector[«type.toUpperCase»_MAX_ORTHOGONAL_STATES];
 			«IF hasHistory»«statesEnumType» historyVector[«type.toUpperCase»_MAX_HISTORY_STATES];«ENDIF»

--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/StatemachineC.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/StatemachineC.xtend
@@ -270,7 +270,7 @@ class StatemachineC {
 	 
 	/** */
 	def functionPrototypes(ExecutionFlow it) '''
-		// prototypes of all internal functions
+		/* prototypes of all internal functions */
 		
 		«checkFunctions.toPrototypes»
 		«effectFunctions.toPrototypes»
@@ -307,7 +307,7 @@ class StatemachineC {
 	 
 	/** */
 	def functionImplementations(ExecutionFlow it) '''
-		// implementations of all internal functions
+		/* implementations of all internal functions */
 		
 		«checkFunctions.toImplementation»
 		«effectFunctions.toImplementation»

--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/StatemachineRequired.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/StatemachineRequired.xtend
@@ -74,11 +74,11 @@ class StatemachineRequired {
 			
 			«ENDFOR»
 			«IF timed»
-			//
-			// This is a timed state machine that requires timer services
-			// 
+			/*!
+			 * This is a timed state machine that requires timer services
+			 */ 
 			
-			//! This function has to set up timers for the time events that are required by the state machine.
+			/*! This function has to set up timers for the time events that are required by the state machine. */
 			/*! 
 				This function will be called for each time event that is relevant for a state when a state will be entered.
 				\param evid An unique identifier of the event.
@@ -87,7 +87,7 @@ class StatemachineRequired {
 			*/
 			extern void «type.toFirstLower»_setTimer(«scHandleDecl», const sc_eventid evid, const sc_integer time_ms, const sc_boolean periodic);
 
-			//! This function has to unset timers for the time events that are required by the state machine.
+			/*! This function has to unset timers for the time events that are required by the state machine. */
 			/*! 
 				This function will be called for each time event taht is relevant for a state when a state will be left.
 				\param evid An unique identifier of the event.


### PR DESCRIPTION
Replaced comments in Statemachine.xtend, StatemachineC.xtend, and
StatemachineRequired.xtend.