### PR TITLE
Ensure pointer to const is used where possible.

### DIFF
--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/Statemachine.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/Statemachine.xtend
@@ -86,16 +86,16 @@ class Statemachine {
 			 * Checks if the statemachine is active (until 2.4.1 this method was used for states).
 			 * A statemachine is active if it was entered. It is inactive if it has not been entered at all or if it was exited.
 			 */
-			extern sc_boolean «isActiveFctID»(«scHandleDecl»);
+			extern sc_boolean «isActiveFctID»(const «scHandleDecl»);
 			
 			/*!
 			 * Checks if all active states are final. 
 			 * If there are no active states then the statemachine is considered as inactive and this method returns false.
 			 */
-			extern sc_boolean «isFinalFctID»(«scHandleDecl»);
+			extern sc_boolean «isFinalFctID»(const «scHandleDecl»);
 			
 			/*! Checks if the specified state is active (until 2.4.1 the used method for states was calles isActive()). */
-			extern sc_boolean «stateActiveFctID»(«scHandleDecl», «statesEnumType» state);
+			extern sc_boolean «stateActiveFctID»(const «scHandleDecl», «statesEnumType» state);
 			
 			#ifdef __cplusplus
 			}
@@ -187,11 +187,11 @@ class Statemachine {
 		
 		«ELSE»
 			/*! Checks if the out event '«name»' that is defined in the «scope.scopeDescription» has been raised. */ 
-			extern sc_boolean «asRaised»(«scHandleDecl»);
+			extern sc_boolean «asRaised»(const «scHandleDecl»);
 			
 			«IF hasValue»
 				/*! Gets the value of the out event '«name»' that is defined in the «scope.scopeDescription». */ 
-				extern «type.targetLanguageName» «asGetter»(«scHandleDecl»);
+				extern «type.targetLanguageName» «asGetter»(const «scHandleDecl»);
 				
 			«ENDIF»
 		«ENDIF»
@@ -199,7 +199,7 @@ class Statemachine {
 
 	def dispatch functionPrototypes(VariableDefinition it) '''
 		/*! Gets the value of the variable '«name»' that is defined in the «scope.scopeDescription». */ 
-		extern «type.targetLanguageName» «it.asGetter»(«scHandleDecl»);
+		extern «type.targetLanguageName» «it.asGetter»(const «scHandleDecl»);
 		«IF !readonly && !const»
 			/*! Sets the value of the variable '«name»' that is defined in the «scope.scopeDescription». */ 
 			extern void «asSetter»(«scHandleDecl», «type.targetLanguageName» value);

--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/StatemachineC.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/StatemachineC.xtend
@@ -175,7 +175,7 @@ class StatemachineC {
 	
 	def raiseTimeEventFunction(ExecutionFlow it) '''
 		«IF timed»
-			void «raiseTimeEventFctID»(«type»* handle, sc_eventid evid) {
+			void «raiseTimeEventFctID»(const «type»* handle, sc_eventid evid) {
 				if ( ((intptr_t)evid) >= ((intptr_t)&(«scHandle»->timeEvents))
 					&&  ((intptr_t)evid) < ((intptr_t)&(«scHandle»->timeEvents)) + sizeof(«timeEventScope.type»)) {
 					*(sc_boolean*)evid = bool_true;
@@ -185,7 +185,7 @@ class StatemachineC {
 	'''
 	
 	def isStateActiveFunction(ExecutionFlow it) '''
-		sc_boolean «stateActiveFctID»(«scHandleDecl», «statesEnumType» state) {
+		sc_boolean «stateActiveFctID»(const «scHandleDecl», «statesEnumType» state) {
 			switch (state) {
 				«FOR s : states»
 				case «s.shortName» : 
@@ -200,7 +200,7 @@ class StatemachineC {
 	
 	def isActiveFunction(ExecutionFlow it) '''
 
-		sc_boolean «isActiveFctID»(«scHandleDecl») {
+		sc_boolean «isActiveFctID»(const «scHandleDecl») {
 			return «FOR i : 0 ..< stateVector.size SEPARATOR '||'»«scHandle»->stateConfVector[«i»] != «null_state»«ENDFOR»;
 		}
 	'''
@@ -214,7 +214,7 @@ class StatemachineC {
 			 * Always returns 'false' since this state machine can never become final.
 			 */
 			«ENDIF»
-			sc_boolean «isFinalFctID»(«scHandleDecl»){
+			sc_boolean «isFinalFctID»(const «scHandleDecl»){
 		''' +
 		// only if the impact vector is completely covered by final states the state machine 
 		// can become final
@@ -241,18 +241,18 @@ class StatemachineC {
 			«ENDFOR»
 			
 			«FOR event : scope.outgoingEvents»
-				sc_boolean «event.asRaised»(«scHandleDecl») {
+				sc_boolean «event.asRaised»(const «scHandleDecl») {
 					return «event.access»;
 				}
 				«IF event.hasValue» 
-					«event.type.targetLanguageName» «event.asGetter»(«scHandleDecl») {
+					«event.type.targetLanguageName» «event.asGetter»(const «scHandleDecl») {
 						return «event.valueAccess»;
 					}
 				«ENDIF»
 			«ENDFOR»
 			
 			«FOR variable : scope.variableDefinitions»
-				«variable.type.targetLanguageName» «variable.asGetter»(«scHandleDecl») {
+				«variable.type.targetLanguageName» «variable.asGetter»(const «scHandleDecl») {
 					return «variable.access»;
 				}
 				«IF !variable.readonly && !variable.const»


### PR DESCRIPTION
Use pointer to const parameters for raiseTimeEvent, isActive, isFinal,
and all event and variable getters.