### PR TITLE
Split scopeTypeDecl into scopeTypeDecl and scopeConstDecl, as these are

### DIFF
--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineHeader.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineHeader.xtend
@@ -152,12 +152,12 @@ class StatemachineHeader extends Statemachine {
 			«entry.innerClassVisibility»:
 				friend class «scope.execution_flow.module()»;
 				«FOR d : scope.declarations»
-					«d.structDeclaration»
+					«d.scopeTypeDeclMember»
 				«ENDFOR»
 		};
 	'''
 
-	override dispatch structDeclaration(VariableDefinition it) '''
+	override dispatch scopeTypeDeclMember(VariableDefinition it) '''
 		«IF type.name != 'void'»«IF const»static const «ENDIF»«type.targetLanguageName» «name.asEscapedIdentifier»;«ENDIF»
 	'''
 


### PR DESCRIPTION
two unrelated aspects.
Rename structDeclaration into scopeTypeDeclMember.
Fix that no scope types are declared when there a no member
declarations. Fix that no state machine type members are created in case
the member struct is empty.