### PR TITLE
#882: Avoid creation of copyAlways link between a sub diagram and the…

### DIFF
--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/clipboardsupport/NotationClipboardOperationHelper.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/clipboardsupport/NotationClipboardOperationHelper.java
@@ -118,13 +118,19 @@ public class NotationClipboardOperationHelper extends AbstractClipboardSupport {
 	 * containment references and the
 	 * {@linkplain org.eclipse.gmf.runtime.notation.View#getElement() element}
 	 * reference always are copied.
+	 * 
+	 * For diagrams, the
+	 * {@linkplain org.eclipse.gmf.runtime.notation.View#getElement() element}
+	 * reference is not copied when the value is a state which indicates the
+	 * copying of a subdiagram, while the state will be copied with the
+	 * corresponding node.
 	 */
 	public boolean isCopyAlways(EObject context, EReference eReference,
 			Object value) {
 		if ((eReference.isTransient()) || (eReference.isDerived())) {
 			return false;
 		} else if (eReference.equals(NotationPackage.eINSTANCE
-				.getView_Element())) {
+				.getView_Element()) && !(context instanceof Diagram && value instanceof State)) {
 			return true;
 		} else {
 			return eReference.isContainment();


### PR DESCRIPTION
… referenced state as the state will be already copying with the corresponding node.