### PR TITLE
Made the "Properties" view visible by default - #771

### DIFF
--- a/plugins/org.yakindu.sct.ui/src/org/yakindu/sct/ui/perspectives/ModelingPerspectiveFactory.java
+++ b/plugins/org.yakindu.sct.ui/src/org/yakindu/sct/ui/perspectives/ModelingPerspectiveFactory.java
@@ -41,9 +41,9 @@ public class ModelingPerspectiveFactory implements IPerspectiveFactory {
 
 		IFolderLayout bottom = layout.createFolder("bottom",
 				IPageLayout.BOTTOM, 0.65f, editorArea);
-		bottom.addView(IPageLayout.ID_TASK_LIST);
-		bottom.addView(IPageLayout.ID_PROBLEM_VIEW);
 		bottom.addView(IPageLayout.ID_PROP_SHEET);
+		bottom.addView(IPageLayout.ID_PROBLEM_VIEW);
+		bottom.addView(IPageLayout.ID_TASK_LIST);
 	}
 
 	private void defineActions(IPageLayout layout) {


### PR DESCRIPTION
Just changes the order of tabs in the bottom editor area so that the properties view is visible first.