### PR TITLE
Change init and behavior of "Show Time Events"

### DIFF
--- a/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/view/SimulationView.java
+++ b/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/view/SimulationView.java
@@ -120,7 +120,7 @@ public class SimulationView extends AbstractDebugTargetView implements ITypeSyst
 		mgr.add(collapse);
 		IAction expand = new ExpandAllAction(viewer);
 		mgr.add(expand);
-		IAction hideTimeEvent = new HideTimeEventsAction(true);
+		IAction hideTimeEvent = new HideTimeEventsAction(false);
 		mgr.add(hideTimeEvent);
 	}
 

--- a/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/view/actions/HideTimeEventsAction.java
+++ b/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/view/actions/HideTimeEventsAction.java
@@ -26,15 +26,15 @@ public class HideTimeEventsAction extends Action {
 
 	public HideTimeEventsAction(boolean show) {
 		super("Hide TimeEvents");
+		getStore().setValue(HIDE_KEY, show);
 		setToolTipText("Show TimeEvents");
 		setImageDescriptor(SimulationImages.TIMEEVENT.imageDescriptor());
-		setChecked(getStore().getBoolean(HIDE_KEY));
+		setChecked(!(getStore().getBoolean(HIDE_KEY)));
 	}
 
 	@Override
 	public void run() {
-		boolean hide = getStore().getBoolean(HIDE_KEY);
-		getStore().setValue(HIDE_KEY, !hide);
+		getStore().setValue(HIDE_KEY, !(getStore().getBoolean(HIDE_KEY)));
 	}
 
 	private IPreferenceStore getStore() {

--- a/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/view/actions/HideTimeEventsAction.java
+++ b/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/view/actions/HideTimeEventsAction.java
@@ -27,7 +27,7 @@ public class HideTimeEventsAction extends Action {
 	public HideTimeEventsAction(boolean show) {
 		super("Hide TimeEvents");
 		getStore().setValue(HIDE_KEY, show);
-		setToolTipText("Show TimeEvents");
+		setToolTipText("Show Time Events");
 		setImageDescriptor(SimulationImages.TIMEEVENT.imageDescriptor());
 		setChecked(!(getStore().getBoolean(HIDE_KEY)));
 	}


### PR DESCRIPTION
The "Show Time Events"-button in the simulation view was acting the exakt
opposite of what a user would expect - the Tooltip says "Show Time Events",
but an activated button would make the time events disappear and vice versa.
The core reason for this is that the changed option is "HideTimeEvents".
If that is set to True, the time events are hidden, and the button is activated.
Now, the button is set to the opposite of the option so that it better fits the
given tooltip. A more lazy approach would have been to change the tooltip to
"Hide Time Events".
Furthermore, an action was put into place so that the default value of the
option is now "False" so that Time Events are displayed by default, making
the usage easier for beginners. Tiny buttons like these are easily overlooked.

Fixes Yakindu/sctpro#424