### PR TITLE
Enable context predicate provider again

### DIFF
--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/ContextPredicateProvider.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/ContextPredicateProvider.java
@@ -194,16 +194,16 @@ public class ContextPredicateProvider {
 
 	public Predicate<IEObjectDescription> calculateFilterPredicate(final EObject context, final EReference reference) {
 		Predicate<IEObjectDescription> predicate = Predicates.alwaysTrue();
-//		EObject container = context;
-//		EReference ref = reference;
-//		while (container != null) {
-//			predicate = getPredicate(container.eClass(), ref);
-//			if (!(predicate instanceof EmptyPredicate)) {
-//				break;
-//			}
-//			ref = (EReference) container.eContainingFeature();
-//			container = container.eContainer();
-//		}
+		EObject container = context;
+		EReference ref = reference;
+		while (container != null) {
+			predicate = getPredicate(container.eClass(), ref);
+			if (!(predicate instanceof EmptyPredicate)) {
+				break;
+			}
+			ref = (EReference) container.eContainingFeature();
+			container = container.eContainer();
+		}
 		return predicate;
 	}
 }

--- a/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/ContextPredicateProviderTest.java
+++ b/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/ContextPredicateProviderTest.java
@@ -14,7 +14,6 @@ import java.util.Arrays;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.junit4.validation.AssertableDiagnostics;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -73,7 +72,6 @@ public class ContextPredicateProviderTest extends AbstractSTextValidationTest {
 	}
 
 	@Test
-	@Ignore
 	public void test() {
 		EObject expression = parseExpression(statement, ruleName, scopes);
 		AssertableDiagnostics validationResult = tester.validate(expression);


### PR DESCRIPTION
This was disabled because complex types containing events could not be used on transition expressions. But this drawback is not relevant open source release.