### PR TITLE
Hotfix for validator malfunction

### DIFF
--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/validation/DomainValidator.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/validation/DomainValidator.java
@@ -35,7 +35,7 @@ public class DomainValidator implements EValidator {
 
 	@Override
 	public boolean validate(EObject eObject, DiagnosticChain diagnostics, Map<Object, Object> context) {
-		return false;
+		return true;
 	}
 
 	@Override
@@ -53,7 +53,7 @@ public class DomainValidator implements EValidator {
 	@Override
 	public boolean validate(EDataType eDataType, Object value, DiagnosticChain diagnostics,
 			Map<Object, Object> context) {
-		return false;
+		return true;
 	}
 
 }


### PR DESCRIPTION
On a Linux machine running OpenJDK, Yakindu SCT validated History-states as
having a bad value in 'kind' (that is ENTRY, HISTORY or DEEP_HISTORY).
This could not be reproduced on a Windows machine.
For some reason, the validator runs into another function on Linux
that always returns false.
This was fixed by simply returning true instead.

Fixes #1080