### PR TITLE
Corrected misspelled basePackeName static return value

### DIFF
--- a/plugins/org.yakindu.sct.generator.java/src/org/yakindu/sct/generator/java/GenmodelEntries.xtend
+++ b/plugins/org.yakindu.sct.generator.java/src/org/yakindu/sct/generator/java/GenmodelEntries.xtend
@@ -72,7 +72,7 @@ class GenmodelEntries {
 		if (basePackageParameter != null) {
 			return basePackageParameter.stringValue
 		}
-		return "org.yakindu.scr"
+		return "org.yakindu.sct"
 	}
 
 	def getImplementationSuffix(GeneratorEntry it, ExecutionFlow flow) {


### PR DESCRIPTION
Just a little fix in the java code generator I came across