### PR TITLE
Remove void and const from typeRelevantDeclarations

### DIFF
--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/StatemachineHeader.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/StatemachineHeader.xtend
@@ -169,7 +169,18 @@ class StatemachineHeader implements IContentTemplate {
 	'''
 	
 	private def typeRelevantDeclarations(Scope scope){
-		return scope.declarations.filter[it instanceof EventDefinition || it instanceof VariableDefinition || it instanceof TimeEvent]
+		return scope.declarations.filter[
+			switch it {
+				case it instanceof EventDefinition: true
+				case it instanceof TimeEvent: true
+				case it instanceof VariableDefinition: {
+					val vd = it as VariableDefinition
+					!vd.const && vd.type.name != "void"
+				}
+				default: false
+			}
+//			it instanceof EventDefinition || it instanceof VariableDefinition || it instanceof TimeEvent
+		]
 	}
 	
 	private def constDeclarations(Scope scope){

--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/StatemachineHeader.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/StatemachineHeader.xtend
@@ -171,15 +171,11 @@ class StatemachineHeader implements IContentTemplate {
 	private def typeRelevantDeclarations(Scope scope){
 		return scope.declarations.filter[
 			switch it {
-				case it instanceof EventDefinition: true
-				case it instanceof TimeEvent: true
-				case it instanceof VariableDefinition: {
-					val vd = it as VariableDefinition
-					!vd.const && vd.type.name != "void"
-				}
+				EventDefinition: true
+				TimeEvent: true
+				VariableDefinition: !it.const
 				default: false
 			}
-//			it instanceof EventDefinition || it instanceof VariableDefinition || it instanceof TimeEvent
 		]
 	}
 	


### PR DESCRIPTION
Just removes the types that are const or void from typeRelevantDeclarations, so that .empty actually returns that it will generate nothing if it won't.

Fixes #1188