### PR TITLE
GMockHelper uses GMock for testing

### DIFF
--- a/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/GMockHelper.java
+++ b/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/GMockHelper.java
@@ -1,0 +1,17 @@
+package org.yakindu.sct.generator.c.gtest;
+
+import java.util.List;
+
+public class GMockHelper extends GTestHelper {
+	public GMockHelper(Object owner) {
+		super(owner);
+	}
+	
+	@Override
+	protected List<String> createCommand() {
+		List<String> command = super.createCommand();
+		command.remove("-lgtest_main");
+		command.add("-lgmock_main");
+		return command;
+	}
+}


### PR DESCRIPTION
This class uses `-lgmock_main` instead of `-lgtest_main` because this lib sets up both GMock and GTest.