### PR TITLE
Adjust filter for SCT nature from root property page 

### DIFF
--- a/plugins/org.yakindu.sct.ui/plugin.xml
+++ b/plugins/org.yakindu.sct.ui/plugin.xml
@@ -37,10 +37,9 @@
             class="org.yakindu.sct.ui.preferences.SctRootPropertyPage"
             id="org.yakindu.sct.ui.properties.root"
             name="YAKINDU SCT">
-         <enabledWhen>
+         	<enabledWhen>
 	            <adapt type="org.eclipse.core.resources.IProject"/>
 			</enabledWhen>
-	     <filter name="projectNature" value="org.yakindu.sct.builder.SCTNature"/>
       </page>
    </extension>
 </plugin>

--- a/plugins/org.yakindu.sct.ui/plugin.xml
+++ b/plugins/org.yakindu.sct.ui/plugin.xml
@@ -37,9 +37,11 @@
             class="org.yakindu.sct.ui.preferences.SctRootPropertyPage"
             id="org.yakindu.sct.ui.properties.root"
             name="YAKINDU SCT">
-         	<enabledWhen>
+        	<enabledWhen>
 	            <adapt type="org.eclipse.core.resources.IProject"/>
 			</enabledWhen>
+	        <filter name="projectNature" value="org.eclipse.cdt.core.cnature"/>
+	        <filter name="projectNature" value="org.eclipse.xtext.ui.shared.xtextNature"/>
       </page>
    </extension>
 </plugin>


### PR DESCRIPTION
the only aspect to discuss is that the root property page will also be visible if no child property page is available 
foolows #1203 

e.g. : c nature, xtext nature missing