### PR TITLE
Set getter / checker functions to const

### DIFF
--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineHeader.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineHeader.xtend
@@ -69,7 +69,7 @@ class StatemachineHeader extends org.yakindu.sct.generator.c.StatemachineHeader 
 				«publicFunctionPrototypes»
 				
 				/*! Checks if the specified state is active (until 2.4.1 the used method for states was calles isActive()). */
-				sc_boolean «stateActiveFctID»(«statesEnumType» state);
+				sc_boolean «stateActiveFctID»(«statesEnumType» state) const;
 			
 			«entry.innerClassVisibility»:
 			
@@ -238,14 +238,14 @@ class StatemachineHeader extends org.yakindu.sct.generator.c.StatemachineHeader 
 		* Checks if the state machine is active (until 2.4.1 this method was used for states).
 		* A state machine is active if it has been entered. It is inactive if it has not been entered at all or if it has been exited.
 		*/
-		virtual sc_boolean isActive();
+		virtual sc_boolean isActive() const;
 		
 		
 		/*!
 		* Checks if all active states are final. 
 		* If there are no active states then the state machine is considered being inactive. In this case this method returns false.
 		*/
-		virtual sc_boolean isFinal();
+		virtual sc_boolean isFinal() const;
 	'''
 	
 	def timedStatemachineFunctions(ExecutionFlow it) '''
@@ -265,11 +265,11 @@ class StatemachineHeader extends org.yakindu.sct.generator.c.StatemachineHeader 
 			void «asRaiser»(«valueParams»);
 			
 			/*! Checks if the out event '«name»' that is defined in the «scope.scopeDescription» has been raised. */
-			sc_boolean «asRaised»();
+			sc_boolean «asRaised»() const;
 			
 			«IF hasValue»
 				/*! Gets the value of the out event '«name»' that is defined in the «scope.scopeDescription». */
-				«typeSpecifier.targetLanguageName» «asGetter»();
+				«typeSpecifier.targetLanguageName» «asGetter»() const;
 				
 			«ENDIF»
 		«ELSEIF direction == Direction::IN»
@@ -278,11 +278,11 @@ class StatemachineHeader extends org.yakindu.sct.generator.c.StatemachineHeader 
 			
 		«ELSE»
 			/*! Checks if the out event '«name»' that is defined in the «scope.scopeDescription» has been raised. */
-			sc_boolean «asRaised»();
+			sc_boolean «asRaised»() const;
 			
 			«IF hasValue»
 				/*! Gets the value of the out event '«name»' that is defined in the «scope.scopeDescription». */
-				«typeSpecifier.targetLanguageName» «asGetter»();
+				«typeSpecifier.targetLanguageName» «asGetter»() const;
 				
 			«ENDIF»
 		«ENDIF»
@@ -290,7 +290,7 @@ class StatemachineHeader extends org.yakindu.sct.generator.c.StatemachineHeader 
 
 	override dispatch functionPrototypes(VariableDefinition it) '''
 		/*! Gets the value of the variable '«name»' that is defined in the «scope.scopeDescription». */
-		«IF const»const «ENDIF»«typeSpecifier.targetLanguageName» «it.asGetter»();
+		«IF const»const «ENDIF»«typeSpecifier.targetLanguageName» «it.asGetter»() const;
 
 		«IF !readonly && !const»
 			/*! Sets the value of the variable '«name»' that is defined in the «scope.scopeDescription». */

--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineImplementation.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineImplementation.xtend
@@ -230,7 +230,7 @@ class StatemachineImplementation implements IContentTemplate {
 	'''
 	
 	def isStateActiveFunction(ExecutionFlow it) '''
-		sc_boolean «module»::«stateActiveFctID»(«statesEnumType» state)
+		sc_boolean «module»::«stateActiveFctID»(«statesEnumType» state) const
 		{
 			switch (state)
 			{
@@ -247,7 +247,7 @@ class StatemachineImplementation implements IContentTemplate {
 	
 	
 	def isActiveFunction(ExecutionFlow it) '''
-		sc_boolean «module»::isActive()
+		sc_boolean «module»::isActive() const
 		{
 			return «FOR i : 0 ..< stateVector.size SEPARATOR '||'»stateConfVector[«i»] != «null_state»«ENDFOR»;
 		}
@@ -261,7 +261,7 @@ class StatemachineImplementation implements IContentTemplate {
 			 * Always returns 'false' since this state machine can never become final.
 			 */
 			«ENDIF»
-			sc_boolean «module»::isFinal()
+			sc_boolean «module»::isFinal() const
 			{
 		''' +
 		// only if the impact vector is completely covered by final states the state machine 
@@ -311,26 +311,26 @@ class StatemachineImplementation implements IContentTemplate {
 				«ENDIF»
 			«ENDFOR»
 			«FOR event : scope.outgoingEvents»
-				sc_boolean «module»::«scope.interfaceName»::«event.asRaised»()
+				sc_boolean «module»::«scope.interfaceName»::«event.asRaised»() const
 				{
 					return «event.localAccess»;
 				}
 				
 				«IF scope.defaultInterface»
-					sc_boolean «module»::«event.asRaised»()
+					sc_boolean «module»::«event.asRaised»() const
 					{
 						return «scope.instance».«event.asRaised»();
 					}
 					
 				«ENDIF»
 				«IF event.hasValue»
-					«event.typeSpecifier.targetLanguageName» «module»::«scope.interfaceName»::«event.asGetter»()
+					«event.typeSpecifier.targetLanguageName» «module»::«scope.interfaceName»::«event.asGetter»() const
 					{
 						return «event.localValueAccess»;
 					}
 					
 					«IF scope.defaultInterface»
-						«event.typeSpecifier.targetLanguageName» «module»::«event.asGetter»()
+						«event.typeSpecifier.targetLanguageName» «module»::«event.asGetter»() const
 						{
 							return «scope.instance».«event.asGetter»();
 						}
@@ -348,13 +348,13 @@ class StatemachineImplementation implements IContentTemplate {
 					«event.localAccess» = true;
 				}
 				
-				sc_boolean «module»::«scope.interfaceName»::«event.asRaised»()
+				sc_boolean «module»::«scope.interfaceName»::«event.asRaised»() const
 				{
 					return «event.localAccess»;
 				}
 				
 				«IF event.hasValue» 
-					«event.typeSpecifier.targetLanguageName» «module»::«scope.interfaceName»::«event.asGetter»()
+					«event.typeSpecifier.targetLanguageName» «module»::«scope.interfaceName»::«event.asGetter»() const
 					{
 						return «event.localValueAccess»;
 					}
@@ -362,13 +362,13 @@ class StatemachineImplementation implements IContentTemplate {
 				«ENDIF»
 			«ENDFOR»
 			«FOR variable : scope.variableDefinitions»
-				«IF variable.const»const «ENDIF»«variable.typeSpecifier.targetLanguageName» «module»::«scope.interfaceName»::«variable.asGetter»()
+				«IF variable.const»const «ENDIF»«variable.typeSpecifier.targetLanguageName» «module»::«scope.interfaceName»::«variable.asGetter»() const
 				{
 					return «variable.localAccess»;
 				}
 				
 				«IF scope.defaultInterface»
-					«IF variable.const»const «ENDIF»«variable.typeSpecifier.targetLanguageName» «module»::«variable.asGetter»()
+					«IF variable.const»const «ENDIF»«variable.typeSpecifier.targetLanguageName» «module»::«variable.asGetter»() const
 					{
 						return «variable.access»;
 					}

--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineInterface.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineInterface.xtend
@@ -58,12 +58,12 @@ class StatemachineInterface implements IContentTemplate {
 				/*! Checks whether the state machine is active. 
 			 	    A state machine is active if it has been entered. It is inactive if it has not been entered at all or if it has been exited.
 			 	*/	
-				virtual	sc_boolean isActive() = 0;
+				virtual	sc_boolean isActive() const = 0;
 				
 				/*! Checks if all active states are final. 
 			 		If there are no active states then the state machine is considered being inactive. In this case this method returns false.
 			 	*/
-				virtual sc_boolean isFinal() = 0;
+				virtual sc_boolean isFinal() const = 0;
 		};
 		
 		inline StatemachineInterface::~StatemachineInterface() {}


### PR DESCRIPTION
Certain functions now have the const modifier added. This allows the compiler
to automatically check no variables are set inside these functions and they
can be invoked on a const pointer.
These functions are:
isStateActive() (resolves #1073)
isActive()
isFinal()
event functions:
isRaised()
getValue()
and all generated getter functions.