### PR TITLE
Add 'optional' attribute to Parameter Type

### DIFF
--- a/plugins/org.yakindu.base.types.edit/plugin.properties
+++ b/plugins/org.yakindu.base.types.edit/plugin.properties
@@ -216,3 +216,5 @@ _UI_GenericElement_type = Generic Element
 _UI_TemplateParameter_bound_feature = Bound
 _UI_GenericElement_templateParameters_feature = Template Parameters
 _UI_GenericElement_typeParameters_feature = Type Parameters
+_UI_Parameter_isOptional_feature = Is Optional
+_UI_Parameter_optional_feature = Optional

--- a/plugins/org.yakindu.base.types.edit/src/org/yakindu/base/types/provider/ComplexTypeItemProvider.java
+++ b/plugins/org.yakindu.base.types.edit/src/org/yakindu/base/types/provider/ComplexTypeItemProvider.java
@@ -32,7 +32,7 @@ import org.yakindu.base.types.TypesPackage;
  * @generated
  */
 public class ComplexTypeItemProvider
-	extends GenericElementItemProvider {
+	extends TypeItemProvider {
 	/**
 	 * This constructs an instance from a factory and a notifier.
 	 * <!-- begin-user-doc -->
@@ -54,101 +54,9 @@ public class ComplexTypeItemProvider
 		if (itemPropertyDescriptors == null) {
 			super.getPropertyDescriptors(object);
 
-			addAnnotationsPropertyDescriptor(object);
-			addIdPropertyDescriptor(object);
-			addAbstractPropertyDescriptor(object);
-			addVisiblePropertyDescriptor(object);
 			addSuperTypesPropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
-	}
-
-	/**
-	 * This adds a property descriptor for the Annotations feature.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	protected void addAnnotationsPropertyDescriptor(Object object) {
-		itemPropertyDescriptors.add
-			(createItemPropertyDescriptor
-				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-				 getResourceLocator(),
-				 getString("_UI_AnnotatableElement_annotations_feature"),
-				 getString("_UI_PropertyDescriptor_description", "_UI_AnnotatableElement_annotations_feature", "_UI_AnnotatableElement_type"),
-				 TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATIONS,
-				 true,
-				 false,
-				 true,
-				 null,
-				 null,
-				 null));
-	}
-
-	/**
-	 * This adds a property descriptor for the Id feature.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	protected void addIdPropertyDescriptor(Object object) {
-		itemPropertyDescriptors.add
-			(createItemPropertyDescriptor
-				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-				 getResourceLocator(),
-				 getString("_UI_PackageMember_id_feature"),
-				 getString("_UI_PropertyDescriptor_description", "_UI_PackageMember_id_feature", "_UI_PackageMember_type"),
-				 TypesPackage.Literals.PACKAGE_MEMBER__ID,
-				 false,
-				 false,
-				 false,
-				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-				 null,
-				 null));
-	}
-
-	/**
-	 * This adds a property descriptor for the Abstract feature.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	protected void addAbstractPropertyDescriptor(Object object) {
-		itemPropertyDescriptors.add
-			(createItemPropertyDescriptor
-				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-				 getResourceLocator(),
-				 getString("_UI_Type_abstract_feature"),
-				 getString("_UI_PropertyDescriptor_description", "_UI_Type_abstract_feature", "_UI_Type_type"),
-				 TypesPackage.Literals.TYPE__ABSTRACT,
-				 true,
-				 false,
-				 false,
-				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
-				 null,
-				 null));
-	}
-
-	/**
-	 * This adds a property descriptor for the Visible feature.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	protected void addVisiblePropertyDescriptor(Object object) {
-		itemPropertyDescriptors.add
-			(createItemPropertyDescriptor
-				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-				 getResourceLocator(),
-				 getString("_UI_Type_visible_feature"),
-				 getString("_UI_PropertyDescriptor_description", "_UI_Type_visible_feature", "_UI_Type_type"),
-				 TypesPackage.Literals.TYPE__VISIBLE,
-				 true,
-				 false,
-				 false,
-				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
-				 null,
-				 null));
 	}
 
 	/**
@@ -185,7 +93,7 @@ public class ComplexTypeItemProvider
 	public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {
 		if (childrenFeatures == null) {
 			super.getChildrenFeatures(object);
-			childrenFeatures.add(TypesPackage.Literals.TYPE__CONSTRAINT);
+			childrenFeatures.add(TypesPackage.Literals.GENERIC_ELEMENT__TYPE_PARAMETERS);
 			childrenFeatures.add(TypesPackage.Literals.COMPLEX_TYPE__FEATURES);
 		}
 		return childrenFeatures;
@@ -241,12 +149,7 @@ public class ComplexTypeItemProvider
 		updateChildren(notification);
 
 		switch (notification.getFeatureID(ComplexType.class)) {
-			case TypesPackage.COMPLEX_TYPE__ID:
-			case TypesPackage.COMPLEX_TYPE__ABSTRACT:
-			case TypesPackage.COMPLEX_TYPE__VISIBLE:
-				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-				return;
-			case TypesPackage.COMPLEX_TYPE__CONSTRAINT:
+			case TypesPackage.COMPLEX_TYPE__TYPE_PARAMETERS:
 			case TypesPackage.COMPLEX_TYPE__FEATURES:
 				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
 				return;
@@ -267,13 +170,8 @@ public class ComplexTypeItemProvider
 
 		newChildDescriptors.add
 			(createChildParameter
-				(TypesPackage.Literals.TYPE__CONSTRAINT,
-				 TypesFactory.eINSTANCE.createTypeConstraint()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(TypesPackage.Literals.TYPE__CONSTRAINT,
-				 TypesFactory.eINSTANCE.createRangeConstraint()));
+				(TypesPackage.Literals.GENERIC_ELEMENT__TYPE_PARAMETERS,
+				 TypesFactory.eINSTANCE.createTypeParameter()));
 
 		newChildDescriptors.add
 			(createChildParameter

--- a/plugins/org.yakindu.base.types.edit/src/org/yakindu/base/types/provider/ParameterItemProvider.java
+++ b/plugins/org.yakindu.base.types.edit/src/org/yakindu/base/types/provider/ParameterItemProvider.java
@@ -72,6 +72,7 @@ public class ParameterItemProvider
 			addNamePropertyDescriptor(object);
 			addAnnotationsPropertyDescriptor(object);
 			addVarArgsPropertyDescriptor(object);
+			addOptionalPropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
 	}
@@ -165,6 +166,28 @@ public class ParameterItemProvider
 	}
 
 	/**
+	 * This adds a property descriptor for the Optional feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addOptionalPropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Parameter_optional_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Parameter_optional_feature", "_UI_Parameter_type"),
+				 TypesPackage.Literals.PARAMETER__OPTIONAL,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
+				 null,
+				 null));
+	}
+
+	/**
 	 * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
 	 * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
 	 * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
@@ -233,6 +256,7 @@ public class ParameterItemProvider
 		switch (notification.getFeatureID(Parameter.class)) {
 			case TypesPackage.PARAMETER__NAME:
 			case TypesPackage.PARAMETER__VAR_ARGS:
+			case TypesPackage.PARAMETER__OPTIONAL:
 				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
 				return;
 			case TypesPackage.PARAMETER__TYPE_SPECIFIER:

--- a/plugins/org.yakindu.base.types/model/types.ecore
+++ b/plugins/org.yakindu.base.types/model/types.ecore
@@ -35,6 +35,8 @@
         eOpposite="#//Operation/parameters"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="varArgs" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"
         defaultValueLiteral="false"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="optional" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"
+        defaultValueLiteral="false"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TypedElement" abstract="true" interface="true">
     <eStructuralFeatures xsi:type="ecore:EReference" name="type" eType="#//Type" changeable="false"

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/Parameter.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/Parameter.java
@@ -19,6 +19,7 @@ import org.yakindu.base.base.NamedElement;
  * <ul>
  *   <li>{@link org.yakindu.base.types.Parameter#getOwningOperation <em>Owning Operation</em>}</li>
  *   <li>{@link org.yakindu.base.types.Parameter#isVarArgs <em>Var Args</em>}</li>
+ *   <li>{@link org.yakindu.base.types.Parameter#isOptional <em>Optional</em>}</li>
  * </ul>
  *
  * @see org.yakindu.base.types.TypesPackage#getParameter()
@@ -80,5 +81,32 @@ public interface Parameter extends TypedElement, NamedElement, AnnotatableElemen
 	 * @generated
 	 */
 	void setVarArgs(boolean value);
+
+	/**
+	 * Returns the value of the '<em><b>Optional</b></em>' attribute.
+	 * The default value is <code>"false"</code>.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Optional</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Optional</em>' attribute.
+	 * @see #setOptional(boolean)
+	 * @see org.yakindu.base.types.TypesPackage#getParameter_Optional()
+	 * @model default="false"
+	 * @generated
+	 */
+	boolean isOptional();
+
+	/**
+	 * Sets the value of the '{@link org.yakindu.base.types.Parameter#isOptional <em>Optional</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Optional</em>' attribute.
+	 * @see #isOptional()
+	 * @generated
+	 */
+	void setOptional(boolean value);
 
 } // Parameter

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/TypesPackage.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/TypesPackage.java
@@ -583,13 +583,22 @@ public interface TypesPackage extends EPackage {
 	int PARAMETER__VAR_ARGS = TYPED_ELEMENT_FEATURE_COUNT + 3;
 
 	/**
+	 * The feature id for the '<em><b>Optional</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PARAMETER__OPTIONAL = TYPED_ELEMENT_FEATURE_COUNT + 4;
+
+	/**
 	 * The number of structural features of the '<em>Parameter</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int PARAMETER_FEATURE_COUNT = TYPED_ELEMENT_FEATURE_COUNT + 4;
+	int PARAMETER_FEATURE_COUNT = TYPED_ELEMENT_FEATURE_COUNT + 5;
 
 
 	/**
@@ -1723,6 +1732,17 @@ public interface TypesPackage extends EPackage {
 	EAttribute getParameter_VarArgs();
 
 	/**
+	 * Returns the meta object for the attribute '{@link org.yakindu.base.types.Parameter#isOptional <em>Optional</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Optional</em>'.
+	 * @see org.yakindu.base.types.Parameter#isOptional()
+	 * @see #getParameter()
+	 * @generated
+	 */
+	EAttribute getParameter_Optional();
+
+	/**
 	 * Returns the meta object for class '{@link org.yakindu.base.types.TypedElement <em>Typed Element</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2329,6 +2349,14 @@ public interface TypesPackage extends EPackage {
 		 * @generated
 		 */
 		EAttribute PARAMETER__VAR_ARGS = eINSTANCE.getParameter_VarArgs();
+
+		/**
+		 * The meta object literal for the '<em><b>Optional</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute PARAMETER__OPTIONAL = eINSTANCE.getParameter_Optional();
 
 		/**
 		 * The meta object literal for the '{@link org.yakindu.base.types.TypedElement <em>Typed Element</em>}' class.

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/impl/ParameterImpl.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/impl/ParameterImpl.java
@@ -41,6 +41,7 @@ import org.yakindu.base.types.TypesPackage;
  *   <li>{@link org.yakindu.base.types.impl.ParameterImpl#getAnnotations <em>Annotations</em>}</li>
  *   <li>{@link org.yakindu.base.types.impl.ParameterImpl#getOwningOperation <em>Owning Operation</em>}</li>
  *   <li>{@link org.yakindu.base.types.impl.ParameterImpl#isVarArgs <em>Var Args</em>}</li>
+ *   <li>{@link org.yakindu.base.types.impl.ParameterImpl#isOptional <em>Optional</em>}</li>
  * </ul>
  *
  * @generated
@@ -105,6 +106,26 @@ public class ParameterImpl extends EObjectImpl implements Parameter {
 	 * @ordered
 	 */
 	protected boolean varArgs = VAR_ARGS_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #isOptional() <em>Optional</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isOptional()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final boolean OPTIONAL_EDEFAULT = false;
+
+	/**
+	 * The cached value of the '{@link #isOptional() <em>Optional</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isOptional()
+	 * @generated
+	 * @ordered
+	 */
+	protected boolean optional = OPTIONAL_EDEFAULT;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -290,6 +311,27 @@ public class ParameterImpl extends EObjectImpl implements Parameter {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public boolean isOptional() {
+		return optional;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setOptional(boolean newOptional) {
+		boolean oldOptional = optional;
+		optional = newOptional;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, TypesPackage.PARAMETER__OPTIONAL, oldOptional, optional));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	@Override
 	public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
@@ -352,6 +394,8 @@ public class ParameterImpl extends EObjectImpl implements Parameter {
 				return getOwningOperation();
 			case TypesPackage.PARAMETER__VAR_ARGS:
 				return isVarArgs();
+			case TypesPackage.PARAMETER__OPTIONAL:
+				return isOptional();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -381,6 +425,9 @@ public class ParameterImpl extends EObjectImpl implements Parameter {
 			case TypesPackage.PARAMETER__VAR_ARGS:
 				setVarArgs((Boolean)newValue);
 				return;
+			case TypesPackage.PARAMETER__OPTIONAL:
+				setOptional((Boolean)newValue);
+				return;
 		}
 		super.eSet(featureID, newValue);
 	}
@@ -408,6 +455,9 @@ public class ParameterImpl extends EObjectImpl implements Parameter {
 			case TypesPackage.PARAMETER__VAR_ARGS:
 				setVarArgs(VAR_ARGS_EDEFAULT);
 				return;
+			case TypesPackage.PARAMETER__OPTIONAL:
+				setOptional(OPTIONAL_EDEFAULT);
+				return;
 		}
 		super.eUnset(featureID);
 	}
@@ -432,6 +482,8 @@ public class ParameterImpl extends EObjectImpl implements Parameter {
 				return getOwningOperation() != null;
 			case TypesPackage.PARAMETER__VAR_ARGS:
 				return varArgs != VAR_ARGS_EDEFAULT;
+			case TypesPackage.PARAMETER__OPTIONAL:
+				return optional != OPTIONAL_EDEFAULT;
 		}
 		return super.eIsSet(featureID);
 	}

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/impl/TypesPackageImpl.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/impl/TypesPackageImpl.java
@@ -432,6 +432,15 @@ public class TypesPackageImpl extends EPackageImpl implements TypesPackage {
 	}
 
 	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getParameter_Optional() {
+		return (EAttribute)parameterEClass.getEStructuralFeatures().get(2);
+	}
+
+	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
@@ -829,6 +838,7 @@ public class TypesPackageImpl extends EPackageImpl implements TypesPackage {
 		parameterEClass = createEClass(PARAMETER);
 		createEReference(parameterEClass, PARAMETER__OWNING_OPERATION);
 		createEAttribute(parameterEClass, PARAMETER__VAR_ARGS);
+		createEAttribute(parameterEClass, PARAMETER__OPTIONAL);
 
 		typedElementEClass = createEClass(TYPED_ELEMENT);
 		createEReference(typedElementEClass, TYPED_ELEMENT__TYPE);
@@ -976,6 +986,7 @@ public class TypesPackageImpl extends EPackageImpl implements TypesPackage {
 		initEClass(parameterEClass, Parameter.class, "Parameter", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getParameter_OwningOperation(), this.getOperation(), this.getOperation_Parameters(), "owningOperation", null, 0, 1, Parameter.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getParameter_VarArgs(), ecorePackage.getEBoolean(), "varArgs", "false", 0, 1, Parameter.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getParameter_Optional(), ecorePackage.getEBoolean(), "optional", "false", 0, 1, Parameter.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(typedElementEClass, TypedElement.class, "TypedElement", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getTypedElement_Type(), this.getType(), null, "type", null, 0, 1, TypedElement.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);


### PR DESCRIPTION
In many languages, parameters of functions can be optional. Most times, this is
done by providing default values in the function declaration:
```
void containsDefaultParams(int a, int b=3) {
    ...
}
```
this function could then be called with:
`containsDefaultParams(1, 2);` as usual, or
`containsDefaultParams(1);` - this would use the default value of 3 for `b`.