### PR TITLE
trivial : export refactoring handler implementations

### DIFF
--- a/plugins/org.yakindu.sct.refactoring/META-INF/MANIFEST.MF
+++ b/plugins/org.yakindu.sct.refactoring/META-INF/MANIFEST.MF
@@ -16,5 +16,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.expressions
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
-Export-Package: org.yakindu.sct.refactoring.proposals,
+Export-Package: org.yakindu.sct.refactoring.handlers.impl,
+ org.yakindu.sct.refactoring.proposals,
  org.yakindu.sct.refactoring.refactor


### PR DESCRIPTION
gives the possibility to reuse concrete refactoring handler
implementations within derived editors.