### PR TITLE
Enforce minimum height of documentation property section

### DIFF
--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/propertysheets/AbstractTwoColumnEditorPropertySection.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/propertysheets/AbstractTwoColumnEditorPropertySection.java
@@ -10,11 +10,14 @@
  */
 package org.yakindu.sct.ui.editor.propertysheets;
 
+import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Layout;
+import org.eclipse.swt.widgets.Text;
 
 /**
  * 
@@ -24,7 +27,9 @@ import org.eclipse.swt.widgets.Layout;
 public abstract class AbstractTwoColumnEditorPropertySection extends
 		AbstractEditorPropertySection {
 
-	protected abstract void createRightColumnControls(Composite rightColumn);
+    protected Text documentation;
+
+    protected abstract void createRightColumnControls(Composite rightColumn);
 
 	protected abstract void createLeftColumnControls(Composite leftColumn);
 
@@ -56,5 +61,12 @@ public abstract class AbstractTwoColumnEditorPropertySection extends
 	protected Layout createRightColumnLayout() {
 		return createBodyLayout();
 	}
+
+    protected void createDocumentationControl(Composite parent) {
+        Label lblDocumentation = getToolkit().createLabel(parent, "Documentation: ");
+        documentation = getToolkit().createText(parent, "", SWT.MULTI | SWT.BORDER | SWT.V_SCROLL | SWT.WRAP);
+        GridDataFactory.fillDefaults().applyTo(lblDocumentation);
+        GridDataFactory.fillDefaults().grab(true, true).hint(parent.getSize()).minSize(100, documentation.getLineHeight() * 3).applyTo(documentation);
+    }
 
 }

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/propertysheets/StatePropertySection.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/propertysheets/StatePropertySection.java
@@ -29,7 +29,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Layout;
-import org.eclipse.swt.widgets.Text;
 import org.yakindu.base.base.BasePackage;
 import org.yakindu.sct.model.sgraph.SGraphPackage;
 import org.yakindu.sct.model.sgraph.State;
@@ -47,7 +46,6 @@ public class StatePropertySection extends AbstractTwoColumnEditorPropertySection
 
 	private Control txtSpecification;
 	private Control txtName;
-	private Text txtDoc;
 
 	private OrderElementControl orderElementControl;
 
@@ -82,13 +80,6 @@ public class StatePropertySection extends AbstractTwoColumnEditorPropertySection
 		GridDataFactory.fillDefaults().span(2, 1).applyTo(lblName);
 		new Label(parent, SWT.NONE);
 		GridDataFactory.fillDefaults().grab(true, false).applyTo(txtName);
-	}
-
-	protected void createDocumentationControl(Composite parent) {
-		Label lblDocumentation = getToolkit().createLabel(parent, "Documentation: ");
-		txtDoc = getToolkit().createText(parent, "", SWT.MULTI | SWT.BORDER | SWT.V_SCROLL | SWT.WRAP);
-		GridDataFactory.fillDefaults().applyTo(lblDocumentation);
-		GridDataFactory.fillDefaults().grab(true, true).hint(parent.getSize()).applyTo(txtDoc);
 	}
 
 	protected void createSpecificationControl(final Composite parent) {
@@ -130,7 +121,7 @@ public class StatePropertySection extends AbstractTwoColumnEditorPropertySection
 		IEMFValueProperty property = EMFEditProperties.value(TransactionUtil.getEditingDomain(eObject),
 				BasePackage.Literals.DOCUMENTED_ELEMENT__DOCUMENTATION);
 		ISWTObservableValue observe = WidgetProperties.text(new int[] { SWT.FocusOut, SWT.DefaultSelection })
-				.observe(txtDoc);
+				.observe(documentation);
 		context.bindValue(observe, property.observe(eObject));
 	}
 

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/propertysheets/StatechartPropertySection.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/propertysheets/StatechartPropertySection.java
@@ -57,7 +57,6 @@ public class StatechartPropertySection extends AbstractTwoColumnEditorPropertySe
 	private Control textControl;
 	private Text txtName;
 	protected OrderElementControl orderElementControl;
-	private Text documentation;
 	private ComboViewer domainCombo;
 
 	@Override
@@ -120,13 +119,6 @@ public class StatechartPropertySection extends AbstractTwoColumnEditorPropertySe
 		orderElementControl = new OrderElementControl(rightColumn, SGraphPackage.Literals.COMPOSITE_ELEMENT__REGIONS,
 				this, "Statechart contains no regions");
 		GridDataFactory.fillDefaults().span(2, 0).grab(true, false).applyTo(orderElementControl);
-	}
-
-	protected void createDocumentationControl(Composite parent) {
-		Label lblDocumentation = getToolkit().createLabel(parent, "Documentation: ");
-		documentation = getToolkit().createText(parent, "", SWT.MULTI | SWT.BORDER | SWT.V_SCROLL | SWT.WRAP);
-		GridDataFactory.fillDefaults().applyTo(lblDocumentation);
-		GridDataFactory.fillDefaults().grab(true, true).hint(parent.getSize()).applyTo(documentation);
 	}
 
 	protected void createSpecificationControl(final Composite parent) {

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/propertysheets/TransitionPropertySection.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/propertysheets/TransitionPropertySection.java
@@ -28,7 +28,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Layout;
-import org.eclipse.swt.widgets.Text;
 import org.yakindu.base.base.BasePackage;
 import org.yakindu.sct.model.sgraph.SGraphPackage;
 import org.yakindu.sct.model.sgraph.Transition;
@@ -44,8 +43,8 @@ import com.google.inject.Injector;
 public class TransitionPropertySection extends AbstractTwoColumnEditorPropertySection {
 
 	private Control textControl;
-	private Text txtDoc;
 
+	@Override
 	protected Layout createLeftColumnLayout() {
 		return new GridLayout(2, false);
 	}
@@ -69,10 +68,15 @@ public class TransitionPropertySection extends AbstractTwoColumnEditorPropertySe
 
 	@Override
 	protected void createRightColumnControls(Composite parent) {
-		Label lblDocumentation = getToolkit().createLabel(parent, "Documentation: ");
-		txtDoc = getToolkit().createText(parent, "", SWT.MULTI | SWT.BORDER | SWT.V_SCROLL | SWT.WRAP);
-		GridDataFactory.fillDefaults().span(2, 1).applyTo(lblDocumentation);
-		GridDataFactory.fillDefaults().grab(true, true).hint(parent.getSize()).applyTo(txtDoc);
+	    createDocumentationControl(parent);
+	}
+	
+	@Override
+	protected void createDocumentationControl(Composite parent) {
+        Label lblDocumentation = getToolkit().createLabel(parent, "Documentation: ");
+        documentation = getToolkit().createText(parent, "", SWT.MULTI | SWT.BORDER | SWT.V_SCROLL | SWT.WRAP);
+        GridDataFactory.fillDefaults().span(2, 1).applyTo(lblDocumentation);
+        GridDataFactory.fillDefaults().grab(true, true).hint(parent.getSize()).minSize(100, documentation.getLineHeight() * 3).applyTo(documentation);
 	}
 
 	@Override
@@ -92,7 +96,7 @@ public class TransitionPropertySection extends AbstractTwoColumnEditorPropertySe
 		IEMFValueProperty property = EMFEditProperties.value(TransactionUtil.getEditingDomain(eObject),
 				BasePackage.Literals.DOCUMENTED_ELEMENT__DOCUMENTATION);
 		ISWTObservableValue observe = WidgetProperties.text(new int[] { SWT.FocusOut, SWT.DefaultSelection }).observe(
-				txtDoc);
+		        documentation);
 		context.bindValue(observe, property.observe(eObject));
 
 	}


### PR DESCRIPTION
This change sets the minimum height of the documentation text field in
the properties to be 3 times the height of a single line. In practice at
least on my windows machine still only 2 lines (and some empty pixels)
are visible at any time.

If this is not done, the text control resizes up to no height at all, if
the remaining controls (like list of transitions in the state) gets
long.

The main change is the line containing "minSize", everything else is removal of duplicated code.