### PR TITLE
Use ResourceService to load libraries that are contributed as xtext

### DIFF
--- a/plugins/org.yakindu.base.expressions/src/org/yakindu/base/expressions/scoping/AbstractLibraryGlobalScopeProvider.java
+++ b/plugins/org.yakindu.base.expressions/src/org/yakindu/base/expressions/scoping/AbstractLibraryGlobalScopeProvider.java
@@ -1,3 +1,13 @@
+/** 
+ * Copyright (c) 2017 committers of YAKINDU and others. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Public License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/legal/epl-v10.html 
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ *
+*/
 package org.yakindu.base.expressions.scoping;
 
 import java.util.Collections;

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/scoping/STextLibraryGlobalScopeProvider.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/scoping/STextLibraryGlobalScopeProvider.java
@@ -3,6 +3,7 @@ package org.yakindu.sct.model.stext.scoping;
 import java.util.Set;
 
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
 import org.yakindu.base.expressions.scoping.AbstractLibraryGlobalScopeProvider;
 
 import com.google.common.collect.Sets;
@@ -18,7 +19,7 @@ public class STextLibraryGlobalScopeProvider extends AbstractLibraryGlobalScopeP
 			.createURI("platform:/plugin/org.yakindu.sct.model.stext.lib/lib/STextLib.xmi");
 
 	@Override
-	public Set<URI> getLibraries() {
+	public Set<URI> getLibraries(Resource context) {
 		return Sets.newHashSet(STEXT_LIB);
 	}
 


### PR DESCRIPTION
If a library is added to the scope that is described via xtext, the
resource should be loaded with the corresponding xtext setup /
ResourceDescriptionStrategy / NameProvider etc.