### PR TITLE
#1359 : ensure rename is not visible in custom editors by default

### DIFF
--- a/plugins/org.yakindu.sct.refactoring/plugin.xml
+++ b/plugins/org.yakindu.sct.refactoring/plugin.xml
@@ -206,6 +206,15 @@
                   commandId="com.yakindu.sct.refactoring.renameElement"
                   label="Rename..."
                   style="push">
+               <visibleWhen
+                     checkEnabled="false">
+                  <with
+                        variable="activeEditorId">
+                     <equals
+                           value="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor">
+                     </equals>
+                  </with>
+               </visibleWhen>
             </command>
          </menu>
       </menuContribution>


### PR DESCRIPTION
* custom editors have to contribute the menu entry explicitly
* supports customizations for languages other than Stext(/languages
based on base.types)