### PR TITLE
disable Perspective switch and source display for non statechart models

### DIFF
--- a/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/model/presenter/SCTSourceDisplayDispatcher.java
+++ b/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/model/presenter/SCTSourceDisplayDispatcher.java
@@ -23,6 +23,7 @@ import org.eclipse.ui.IPartListener;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PlatformUI;
+import org.yakindu.sct.simulation.core.debugmodel.IDebugConstants;
 import org.yakindu.sct.simulation.core.debugmodel.SCTDebugElement;
 import org.yakindu.sct.simulation.core.debugmodel.SCTDebugTarget;
 import org.yakindu.sct.simulation.core.engine.ISimulationEngine;
@@ -48,7 +49,7 @@ public class SCTSourceDisplayDispatcher implements ISourceDisplay, IDebugEventSe
 
 	public void displaySource(Object element, IWorkbenchPage page, boolean forceSourceLookup) {
 		SCTDebugTarget newTarget = unwrapTarget(element);
-		if (newTarget.getDebugTarget().isTerminated())
+		if (!newTarget.getModelIdentifier().equals(IDebugConstants.ID_DEBUG_MODEL) || newTarget.getDebugTarget().isTerminated())
 			return;
 		if (newTarget != null && activeDebugTarget != newTarget){
 			if (activeSourceDisplay != null)

--- a/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/perspective/SCTPerspectiveManager.java
+++ b/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/perspective/SCTPerspectiveManager.java
@@ -46,13 +46,13 @@ import org.yakindu.sct.simulation.core.debugmodel.SCTDebugTarget;
 public class SCTPerspectiveManager extends PerspectiveManager implements ILaunchListener, IDebugEventSetListener {
 
 	private static final String DEBUG_VIEW_ID = "org.eclipse.debug.ui.DebugView";
-	private static final String LAUNCH_TYPE = "yakindu";
+	private static final String LAUNCH_TYPE = "org.yakindu.sct.simulation.core.launch.statechart";
 
 	public void launchAdded(ILaunch launch) {
 		try {
 			ILaunchConfigurationType type = launch.getLaunchConfiguration().getType();
 			// Open the simulation perspective for all yakindu simulation types
-			if (type.getIdentifier().contains(LAUNCH_TYPE)) {
+			if (type.getIdentifier().equals(LAUNCH_TYPE)) {
 				schedulePerspectiveSwitchJob(ID_PERSPECTIVE_SCT_SIMULATION);
 			}
 		} catch (CoreException ex) {


### PR DESCRIPTION
This is required for SCTUnit. When we execute a test case we don't want
the statechart model to be opened or the perspective to be switched.