### PR TITLE
Add check & warning for sgen that does not contain any entries

### DIFF
--- a/plugins/org.yakindu.sct.generator.genmodel/src/org/yakindu/sct/generator/genmodel/validation/SGenJavaValidator.java
+++ b/plugins/org.yakindu.sct.generator.genmodel/src/org/yakindu/sct/generator/genmodel/validation/SGenJavaValidator.java
@@ -16,6 +16,7 @@ import static com.google.common.collect.Iterables.transform;
 
 import java.util.List;
 
+import org.antlr.grammar.v3.ANTLRv3Parser.finallyClause_return;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.xtext.EcoreUtil2;
@@ -68,6 +69,7 @@ public class SGenJavaValidator extends AbstractSGenJavaValidator {
 	public static final String INCOMPATIBLE_TYPE_STRING_EXPECTED = "Incompatible type, String expected";
 	public static final String UNKNOWN_CONTENT_TYPE = "Unknown content type '";
 	public static final String DEPRECATED = "Element is depricated";
+	public static final String EMPTY_SGEN = ".sgen file does not contain any entries";
 	// Failure codes
 	public static final String CODE_REQUIRED_FEATURE = "code_req_feature";
 
@@ -148,6 +150,14 @@ public class SGenJavaValidator extends AbstractSGenJavaValidator {
 					SGenPackage.Literals.GENERATOR_MODEL__GENERATOR_ID);
 		}
 	}
+	
+	@Check
+	public void checkEntriesExist(GeneratorModel model) {
+		if(model.getEntries() == null || model.getEntries().isEmpty()) {
+			warning(EMPTY_SGEN, null);
+		}
+	}
+	
 
 	@Check
 	public void checkDuplicateGeneratorEntryFeature(final FeatureConfiguration config) {
@@ -226,7 +236,7 @@ public class SGenJavaValidator extends AbstractSGenJavaValidator {
 						transform(
 								filter(concat(transform(transform(libraryDescriptors, getFeatureTypeLibrary()),
 										getFeatureTypes())), hasName(configuration.getType().getName())),
-								getParmeter())),
+								getParameter())),
 						isRequiredParamter()),
 				getName());
 
@@ -245,7 +255,7 @@ public class SGenJavaValidator extends AbstractSGenJavaValidator {
 	@Check
 	public void checkDeprecatedParameters(GeneratorEntry entry) {
 		Iterable<FeatureParameter> deprecatedParameters = filter(
-				concat(transform(transform(entry.getFeatures(), getFeatureType()), getParmeter())), isDeprecated());
+				concat(transform(transform(entry.getFeatures(), getFeatureType()), getParameter())), isDeprecated());
 		for (FeatureParameter parameter : deprecatedParameters) {
 			warning(String.format(DEPRECATED + " %s : %s", parameter.getName(), parameter.getComment()),
 					SGenPackage.Literals.GENERATOR_ENTRY__ELEMENT_REF, parameter.getName());
@@ -278,7 +288,7 @@ public class SGenJavaValidator extends AbstractSGenJavaValidator {
 		};
 	}
 
-	private Function<FeatureType, Iterable<FeatureParameter>> getParmeter() {
+	private Function<FeatureType, Iterable<FeatureParameter>> getParameter() {
 		return new Function<FeatureType, Iterable<FeatureParameter>>() {
 
 			public Iterable<FeatureParameter> apply(FeatureType from) {

--- a/plugins/org.yakindu.sct.generator.genmodel/src/org/yakindu/sct/generator/genmodel/validation/SGenJavaValidator.java
+++ b/plugins/org.yakindu.sct.generator.genmodel/src/org/yakindu/sct/generator/genmodel/validation/SGenJavaValidator.java
@@ -16,7 +16,6 @@ import static com.google.common.collect.Iterables.transform;
 
 import java.util.List;
 
-import org.antlr.grammar.v3.ANTLRv3Parser.finallyClause_return;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.xtext.EcoreUtil2;

--- a/test-plugins/org.yakindu.sct.generator.genmodel.test/src/org/yakindu/sct/generator/genmodel/test/SGenJavaValidatorTest.java
+++ b/test-plugins/org.yakindu.sct.generator.genmodel.test/src/org/yakindu/sct/generator/genmodel/test/SGenJavaValidatorTest.java
@@ -19,6 +19,7 @@ import static org.yakindu.sct.generator.genmodel.validation.SGenJavaValidator.MI
 import static org.yakindu.sct.generator.genmodel.validation.SGenJavaValidator.MISSING_REQUIRED_PARAMETER;
 import static org.yakindu.sct.generator.genmodel.validation.SGenJavaValidator.UNKNOWN_CONTENT_TYPE;
 import static org.yakindu.sct.generator.genmodel.validation.SGenJavaValidator.UNKOWN_GENERATOR;
+import static org.yakindu.sct.generator.genmodel.validation.SGenJavaValidator.EMPTY_SGEN;
 
 import java.lang.reflect.Method;
 
@@ -199,6 +200,23 @@ public class SGenJavaValidatorTest extends AbstractSGenTest {
 					.getParameters().get(0).setDeprecated(true);
 			AssertableDiagnostics result = tester.validate(genModel);
 			result.assertAny(new MsgPredicate(DEPRECATED));
+		}
+	}
+	
+	/**
+	 * @see SGenJavaValidator#checkDeprecatedParameters(GeneratorEntry)
+	 */
+	@Test
+	public void checkEntriesExist() {
+		EObject model = parseExpression(
+				"GeneratorModel for yakindu::java {}",
+				GeneratorModel.class.getSimpleName());
+		if (!(model instanceof GeneratorModel)) {
+			fail("Model is of the wrong type");
+		} else {
+			GeneratorModel genModel = (GeneratorModel) model;
+			AssertableDiagnostics result = tester.validate(genModel);
+			result.assertAny(new MsgPredicate(EMPTY_SGEN));
 		}
 	}
 


### PR DESCRIPTION
The following sgen content will now create a warning:

```
GeneratorModel for yakindu::java {
}
```

The text is simply ".sgen file does not contain any entries"

Resolves #1381