### PR TITLE
Null-safe handling of text calculation

### DIFF
--- a/plugins/org.yakindu.base.types.edit/src/org/yakindu/base/types/provider/PropertyItemProvider.java
+++ b/plugins/org.yakindu.base.types.edit/src/org/yakindu/base/types/provider/PropertyItemProvider.java
@@ -144,10 +144,13 @@ public class PropertyItemProvider
 	 */
 	@Override
 	public String getText(Object object) {
-		Property variable = (Property)object;
-		StringBuilder builder = new StringBuilder(variable.getName());
-		builder.append(" : ");
-		if(variable.getType() != null)
+		Property variable = (Property) object;
+		StringBuilder builder = new StringBuilder();
+		if (variable.getName() != null) {
+			builder.append(variable.getName());
+			builder.append(" : ");
+		}
+		if (variable.getType() != null)
 			builder.append(variable.getType().getName());
 		else
 			builder.append("unknown");


### PR DESCRIPTION
Theoretically we could define a property without a name, then we will run into an NPE when, e.g. displaying the element in outline view.