### PR TITLE
disables auto reveal on selection #1393

### DIFF
--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editparts/RegionEditPart.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editparts/RegionEditPart.java
@@ -14,6 +14,7 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.StackLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
@@ -28,6 +29,7 @@ import org.eclipse.gmf.runtime.gef.ui.figures.NodeFigure;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
 import org.yakindu.sct.ui.editor.editor.figures.RegionFigure;
+import org.yakindu.sct.ui.editor.editparts.tracker.NonRevealingDragEditPartsTrackerEx;
 import org.yakindu.sct.ui.editor.policies.PreferredSizeHandlerEditPolicy;
 import org.yakindu.sct.ui.editor.preferences.StatechartColorConstants;
 
@@ -83,6 +85,11 @@ public class RegionEditPart extends ShapeNodeEditPart {
 
 	private RegionFigure getPrimaryShape() {
 		return (RegionFigure) getFigure().getChildren().get(0);
+	}
+
+	@Override
+	public DragTracker getDragTracker(Request request) {
+		return new NonRevealingDragEditPartsTrackerEx(this);
 	}
 
 	@Override

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editparts/StateEditPart.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editparts/StateEditPart.java
@@ -20,6 +20,7 @@ import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
@@ -42,6 +43,7 @@ import org.yakindu.sct.model.sgraph.State;
 import org.yakindu.sct.ui.editor.editor.figures.StateFigure;
 import org.yakindu.sct.ui.editor.editor.figures.utils.GridDataFactory;
 import org.yakindu.sct.ui.editor.editor.figures.utils.MapModeUtils;
+import org.yakindu.sct.ui.editor.editparts.tracker.NonRevealingDragEditPartsTrackerEx;
 import org.yakindu.sct.ui.editor.partitioning.DiagramPartitioningUtil;
 import org.yakindu.sct.ui.editor.policies.EnlargeContainerEditPolicy;
 import org.yakindu.sct.ui.editor.policies.FeedbackGraphicalNodeEditPolicy;
@@ -241,6 +243,11 @@ public class StateEditPart extends ShapeNodeEditPart implements IPrimaryEditPart
 	@Override
 	public State resolveSemanticElement() {
 		return (State) super.resolveSemanticElement();
+	}
+	
+	@Override
+	public DragTracker getDragTracker(Request request) {
+		return new NonRevealingDragEditPartsTrackerEx(this);
 	}
 
 	@Override

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editparts/tracker/NonRevealingDragEditPartsTrackerEx.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editparts/tracker/NonRevealingDragEditPartsTrackerEx.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2017 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * 	committers of YAKINDU - initial API and implementation
+ * 
+ */
+package org.yakindu.sct.ui.editor.editparts.tracker;
+
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.tools.TargetingTool;
+import org.eclipse.gmf.runtime.diagram.ui.tools.DragEditPartsTrackerEx;
+
+/**
+ * 
+ * @author andreas muelder - Initial contribution and API
+ * 
+ */
+public class NonRevealingDragEditPartsTrackerEx extends DragEditPartsTrackerEx {
+
+	private static final int FLAG_ENABLE_DIRECT_EDIT = TargetingTool.MAX_FLAG << 2;
+
+	public NonRevealingDragEditPartsTrackerEx(EditPart sourceEditPart) {
+		super(sourceEditPart);
+	}
+
+	@Override
+	protected void reveal(EditPart editpart) {
+		// No reveal on selection
+	}
+
+	@Override
+	protected boolean handleButtonUp(int button) {
+		if (isInState(STATE_DRAG)) {
+			performSelection();
+			if (getFlag(FLAG_ENABLE_DIRECT_EDIT))
+				performDirectEdit();
+			if (button == 1 && getSourceEditPart().getSelected() != EditPart.SELECTED_NONE)
+				reveal(getSourceEditPart());
+			setState(STATE_TERMINAL);
+			return true;
+		}
+		return false;
+	}
+}

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editparts/tracker/NonRevealingDragEditPartsTrackerEx.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editparts/tracker/NonRevealingDragEditPartsTrackerEx.java
@@ -34,6 +34,12 @@ public class NonRevealingDragEditPartsTrackerEx extends DragEditPartsTrackerEx {
 
 	@Override
 	protected boolean handleButtonUp(int button) {
+		if (stateTransition(STATE_DRAG_IN_PROGRESS, STATE_TERMINAL)) {
+			eraseSourceFeedback();
+			eraseTargetFeedback();
+			performDrag();
+			return true;
+		}
 		if (isInState(STATE_DRAG)) {
 			performSelection();
 			if (getFlag(FLAG_ENABLE_DIRECT_EDIT))


### PR DESCRIPTION
Change the default behavior to not moving the diagram if the user
selects an editpart