### PR TITLE
Transform package members only (pro issue 936)

### DIFF
--- a/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/transformation/StructureMapping.xtend
+++ b/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/transformation/StructureMapping.xtend
@@ -82,7 +82,7 @@ class StructureMapping {
 			if (pkgImport !== null && URIConverter.INSTANCE.exists(pkgImport.getUri(), null)) {
 				val packageForNamespace = scope.eResource.resourceSet.getResource(pkgImport.uri, true).contents.
 					head as Package
-				packageForNamespace.eAllContents.filter(Declaration).toList.forEach[createImportDeclaration(_scope)]
+				packageForNamespace.member.filter(Declaration).toList.forEach[createImportDeclaration(_scope)]
 			}
 		}
 		return _scope


### PR DESCRIPTION
Otherwise, also declarations within complex types will be transformed as import declarations and thereby get visible as top level elements in simulation view.

fixes Yakindu/sctpro#936