### PR TITLE
Yakindu/sctpro#960 : avoid ghost markers

### DIFF
--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/validation/DefaultResourceChangeToIssueProcessor.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/validation/DefaultResourceChangeToIssueProcessor.java
@@ -27,7 +27,7 @@ import org.yakindu.sct.model.sgraph.ui.validation.ISctIssueCreator;
 import org.yakindu.sct.model.sgraph.ui.validation.SCTIssue;
 import org.yakindu.sct.model.sgraph.ui.validation.SCTMarkerType;
 
-import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -51,7 +51,7 @@ public class DefaultResourceChangeToIssueProcessor implements IResourceChangeToI
 		if (deltaForFile == null) {
 			return null;
 		}
-		currentIssues = ArrayListMultimap.create(visibleIssues);
+		currentIssues = HashMultimap.create(visibleIssues);
 		changedIssuesElementIDs = Sets.newHashSet();
 		
 		if ((IResourceDelta.CHANGED == deltaForFile.getKind()) && ((deltaForFile.getFlags() & IResourceDelta.MARKERS) != 0)) {


### PR DESCRIPTION
* ghosts comming from live validation, resource changes will not remove
these markers when triggered from diagram partitioning
* fixed by using a HashMultimap instead of ArrayListMultimap to let
handle duplicates implicitly (see SCTIssue.equals & SCTIssue.hashCode)