### PR TITLE
Reload genmodel

### DIFF
--- a/plugins/org.yakindu.base.types/model/types.genmodel
+++ b/plugins/org.yakindu.base.types/model/types.genmodel
@@ -6,28 +6,102 @@
   <foreignModel>types.ecore</foreignModel>
   <genPackages prefix="Types" basePackage="org.yakindu.base" disposableProviderFactory="true"
       ecorePackage="types.ecore#/">
-    <genClasses ecoreClass="types.ecore#//Library">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//Library/types"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//Library/id"/>
+    <genEnums typeSafeEnumCompatible="false" ecoreEnum="types.ecore#//Direction">
+      <genEnumLiterals ecoreEnumLiteral="types.ecore#//Direction/LOCAL"/>
+      <genEnumLiterals ecoreEnumLiteral="types.ecore#//Direction/IN"/>
+      <genEnumLiterals ecoreEnumLiteral="types.ecore#//Direction/OUT"/>
+    </genEnums>
+    <genClasses ecoreClass="types.ecore#//Package">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//Package/member"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//Package/domain"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference types.ecore#//Package/import"/>
     </genClasses>
     <genClasses ecoreClass="types.ecore#//Type">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//Type/features"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference types.ecore#//Type/superTypes"/>
-      <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference types.ecore#//Type/owningLibrary"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//Type/constraint"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//Type/abstract"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//Type/visible"/>
+      <genOperations ecoreOperation="types.ecore#//Type/getOriginType"/>
     </genClasses>
-    <genClasses ecoreClass="types.ecore#//Feature">
-      <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference types.ecore#//Feature/owningType"/>
-    </genClasses>
+    <genClasses image="false" ecoreClass="types.ecore#//Declaration"/>
     <genClasses ecoreClass="types.ecore#//Operation">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//Operation/parameters"/>
+      <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//Operation/variadic"/>
+      <genOperations ecoreOperation="types.ecore#//Operation/getVarArgIndex"/>
     </genClasses>
-    <genClasses ecoreClass="types.ecore#//Property"/>
+    <genClasses ecoreClass="types.ecore#//Property">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//Property/const"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//Property/readonly"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//Property/external"/>
+    </genClasses>
     <genClasses ecoreClass="types.ecore#//Parameter">
       <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference types.ecore#//Parameter/owningOperation"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//Parameter/varArgs"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//Parameter/optional"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//Parameter/annotations"/>
     </genClasses>
     <genClasses ecoreClass="types.ecore#//TypedElement">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference types.ecore#//TypedElement/type"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//TypedElement/typeSpecifier"/>
     </genClasses>
-    <genClasses ecoreClass="types.ecore#//Event"/>
+    <genClasses ecoreClass="types.ecore#//TypeSpecifier">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference types.ecore#//TypeSpecifier/type"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//TypeSpecifier/typeArguments"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//Event">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//Event/direction"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//EnumerationType">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//EnumerationType/enumerator"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//PrimitiveType">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference types.ecore#//PrimitiveType/baseType"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//ComplexType">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//ComplexType/features"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference types.ecore#//ComplexType/superTypes"/>
+      <genOperations ecoreOperation="types.ecore#//ComplexType/getAllFeatures"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//Enumerator">
+      <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference types.ecore#//Enumerator/owningEnumeration"/>
+      <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//Enumerator/literalValue"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//TypeConstraint">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//TypeConstraint/value"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//TypeParameter">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference types.ecore#//TypeParameter/bound"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//GenericElement">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//GenericElement/typeParameters"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//PackageMember">
+      <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//PackageMember/id"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//PackageMember/annotations"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//RangeConstraint">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//RangeConstraint/lowerBound"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//RangeConstraint/upperBound"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//Domain">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//Domain/domainID"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//TypeAlias"/>
+    <genClasses ecoreClass="types.ecore#//Annotation">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference types.ecore#//Annotation/type"/>
+    </genClasses>
+    <genClasses image="false" ecoreClass="types.ecore#//AnnotatableElement">
+      <genOperations ecoreOperation="types.ecore#//AnnotatableElement/getAnnotations"/>
+      <genOperations ecoreOperation="types.ecore#//AnnotatableElement/getAnnotationOfType">
+        <genParameters ecoreParameter="types.ecore#//AnnotatableElement/getAnnotationOfType/typeName"/>
+      </genOperations>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//ArrayTypeSpecifier">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute types.ecore#//ArrayTypeSpecifier/size"/>
+      <genOperations ecoreOperation="types.ecore#//ArrayTypeSpecifier/getElementType"/>
+    </genClasses>
+    <genClasses ecoreClass="types.ecore#//AnnotationType">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference types.ecore#//AnnotationType/properties"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference types.ecore#//AnnotationType/targets"/>
+    </genClasses>
   </genPackages>
 </genmodel:GenModel>


### PR DESCRIPTION
Otherwise, using xcore for meta models that make use of the type meta model shows strange errors with message "A generic super type must refer to a class". The reason for that is not clear, but reloading the genmodel helped.