### PR TITLE
Run type validation for all operation call arguments (#1483)

### DIFF
--- a/plugins/org.yakindu.base.expressions/src/org/yakindu/base/expressions/inferrer/ExpressionsTypeInferrer.java
+++ b/plugins/org.yakindu.base.expressions/src/org/yakindu/base/expressions/inferrer/ExpressionsTypeInferrer.java
@@ -298,17 +298,17 @@ public class ExpressionsTypeInferrer extends AbstractTypeSystemInferrer implemen
 			Map<TypeParameter, InferenceResult> typeParameterMapping, Operation operation, List<Expression> args,
 			IValidationIssueAcceptor acceptor) {
 		List<Parameter> parameters = operation.getParameters();
-		if (parameters.size() <= args.size()) {
 			for (int i = 0; i < parameters.size(); i++) {
-				Parameter parameter = parameters.get(i);
-				Expression argument = args.get(i);
-				InferenceResult parameterType = inferTypeDispatch(parameter);
-				InferenceResult argumentType = inferTypeDispatch(argument);
-				parameterType = typeParameterInferrer.buildInferenceResult(parameterType, typeParameterMapping,
-						acceptor);
-				assertAssignable(parameterType, argumentType,
-						String.format(INCOMPATIBLE_TYPES, argumentType, parameterType));
-			}
+				if (args.size() > i) {
+					Parameter parameter = parameters.get(i);
+					Expression argument = args.get(i);
+					InferenceResult parameterType = inferTypeDispatch(parameter);
+					InferenceResult argumentType = inferTypeDispatch(argument);
+					parameterType = typeParameterInferrer.buildInferenceResult(parameterType, typeParameterMapping,
+							acceptor);
+					assertAssignable(parameterType, argumentType,
+							String.format(INCOMPATIBLE_TYPES, argumentType, parameterType));
+				}
 		}
 		if (operation.isVariadic() && args.size() - 1 >= operation.getVarArgIndex()) {
 			Parameter parameter = operation.getParameters().get(operation.getVarArgIndex());

--- a/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/util/AbstractTypeInferrerTest.java
+++ b/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/util/AbstractTypeInferrerTest.java
@@ -109,31 +109,70 @@ public abstract class AbstractTypeInferrerTest extends AbstractSTextTest {
 						.iterator().next().getMessage());
 	}
 	
+	protected void expectNoErrors(EObject element) {
+		ListBasedValidationIssueAcceptor diagnostics = validate(element);
+		assertNoErrors(diagnostics);
+	}
+	
 	protected void expectNoErrors(String expression, String scope) {
 		ListBasedValidationIssueAcceptor diagnostics = validate(expression, scope);
+		assertNoErrors(diagnostics);
+	}
+	
+	protected void assertNoErrors(ListBasedValidationIssueAcceptor diagnostics) {
 		List<ValidationIssue> errors = diagnostics.getTraces(Severity.ERROR);
 		assertEquals(errors.toString(), 0, errors.size());
 	}
 	
+	protected void expectWarning(EObject element, String code) {
+		ListBasedValidationIssueAcceptor diagnostics = validate(element);
+		assertWarning(diagnostics, code);
+	}
+	
 	protected void expectWarning(String expression, String scope, String code) {
-		List<ValidationIssue> traces = validate(expression, scope).getTraces(Severity.WARNING);
+		ListBasedValidationIssueAcceptor diagnostics = validate(expression, scope);
+		assertWarning(diagnostics, code);
+	}
+
+	protected void assertWarning(ListBasedValidationIssueAcceptor diagnostics, String code) {
+		List<ValidationIssue> traces = diagnostics.getTraces(Severity.WARNING);
 		List<ValidationIssue> issues = filterForIssueCode(traces, code);
 		assertEquals(Arrays.toString(traces.toArray()), 1, issues.size());
+	}
+
+	protected void expectError(EObject element, String code) {
+		ListBasedValidationIssueAcceptor diagnostics = validate(element);
+		assertError(diagnostics, code);
 	}
 	
 	protected void expectError(String expression, String scope, String code) {
-		List<ValidationIssue> traces = validate(expression, scope).getTraces(Severity.ERROR);
+		ListBasedValidationIssueAcceptor diagnostics = validate(expression, scope);
+		assertError(diagnostics, code);
+	}
+
+	protected void assertError(ListBasedValidationIssueAcceptor diagnostics, String code) {
+		List<ValidationIssue> traces = diagnostics.getTraces(Severity.ERROR);
 		List<ValidationIssue> issues = filterForIssueCode(traces, code);
 		assertEquals(Arrays.toString(traces.toArray()), 1, issues.size());
 	}
 	
+	protected void expectErrors(EObject element, String code, int noOfErrors) {
+		ListBasedValidationIssueAcceptor diagnostics = validate(element);
+		assertErrors(diagnostics, code, noOfErrors);
+	}
+	
 	protected void expectErrors(String expression, String scope, String code, int noOfErrors) {
-		List<ValidationIssue> traces = validate(expression, scope).getTraces(Severity.ERROR);
+		ListBasedValidationIssueAcceptor diagnostics = validate(expression, scope);
+		assertErrors(diagnostics, code, noOfErrors);
+	}
+
+	protected void assertErrors(ListBasedValidationIssueAcceptor diagnostics, String code, int noOfErrors) {
+		List<ValidationIssue> traces = diagnostics.getTraces(Severity.ERROR);
 		List<ValidationIssue> issues = filterForIssueCode(traces, code);
 		assertEquals(Arrays.toString(traces.toArray()), noOfErrors, issues.size());
 	}
 	
-	private List<ValidationIssue> filterForIssueCode(List<ValidationIssue> traces, final String code) {
+	protected List<ValidationIssue> filterForIssueCode(List<ValidationIssue> traces, final String code) {
 		return Lists.newArrayList(Iterables.filter(traces, new Predicate<ValidationIssue>() {
 			@Override
 			public boolean apply(ValidationIssue input) {
@@ -144,8 +183,12 @@ public abstract class AbstractTypeInferrerTest extends AbstractSTextTest {
 	
 	protected ListBasedValidationIssueAcceptor validate(String expression, String scope) {
 		EObject exp = parseExpression(expression, Expression.class.getSimpleName(), scope);
+		return validate(exp);
+	}
+	
+	protected ListBasedValidationIssueAcceptor validate(EObject element) {
 		ListBasedValidationIssueAcceptor diagnostics = new ListBasedValidationIssueAcceptor();
-		typeInferrer.infer(exp, diagnostics);
+		typeInferrer.infer(element, diagnostics);
 		return diagnostics;
 	}
 }

--- a/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/util/StextTestFactory.java
+++ b/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/util/StextTestFactory.java
@@ -12,7 +12,10 @@
 package org.yakindu.sct.model.stext.test.util;
 
 
+import java.util.Arrays;
+
 import org.yakindu.base.base.NamedElement;
+import org.yakindu.base.expressions.expressions.Argument;
 import org.yakindu.base.expressions.expressions.AssignmentExpression;
 import org.yakindu.base.expressions.expressions.AssignmentOperator;
 import org.yakindu.base.expressions.expressions.BoolLiteral;
@@ -321,6 +324,14 @@ public class StextTestFactory extends StextFactoryImpl {
 		FeatureCall oc = ExpressionsFactory.eINSTANCE.createFeatureCall();
 		oc.setFeature(o);
 		oc.setOperationCall(true);
+		return oc;
+	}
+	
+	public static ElementReferenceExpression _createOperationCall(OperationDefinition o, Argument... arguments) {
+		ElementReferenceExpression oc = ExpressionsFactory.eINSTANCE.createElementReferenceExpression();
+		oc.setReference(o);
+		oc.setOperationCall(true);
+		oc.getArguments().addAll(Arrays.asList(arguments));
 		return oc;
 	}
 

--- a/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/util/TypesTestFactory.xtend
+++ b/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/util/TypesTestFactory.xtend
@@ -33,17 +33,30 @@ class TypesTestFactory {
 	}
 
 	def createParameter(String name, String typeName) {
-		createParameter(name, toTypeSpecifier(ts.getType(typeName)));
+		createParameter(name, typeName, false);
+	}
+	
+	def createParameter(String name, String typeName, boolean isOptional) {
+		createParameter(name, toTypeSpecifier(ts.getType(typeName)), isOptional);
 	}
 
 	def createParameter(String name, Type type) {
-		createParameter(name, type.toTypeSpecifier);
+		createParameter(name, type.toTypeSpecifier, false);
+	}
+	
+	def createParameter(String name, Type type, boolean isOptional) {
+		createParameter(name, type.toTypeSpecifier, isOptional);
 	}
 
 	def createParameter(String name, TypeSpecifier typeSpec) {
+		createParameter(name, typeSpec, false)
+	}
+	
+	def createParameter(String name, TypeSpecifier typeSpec, boolean isOptional) {
 		factory.createParameter => [
 			it.name = name
 			it.typeSpecifier = typeSpec
+			it.optional = isOptional
 		]
 	}
 


### PR DESCRIPTION
Since parameters can be optional it is valid to have less arguments than parameters, hence we need to validate all given arguments.