### PR TITLE
Enable validation also for generator tests

### DIFF
--- a/test-plugins/org.yakindu.sct.generator.c.test/all C generator tests.launch
+++ b/test-plugins/org.yakindu.sct.generator.c.test/all C generator tests.launch
@@ -4,6 +4,7 @@
 <booleanAttribute key="askclear" value="false"/>
 <booleanAttribute key="automaticAdd" value="true"/>
 <booleanAttribute key="automaticValidate" value="false"/>
+<stringAttribute key="bad_container_name" value="/org.yakindu.sct.generator.cc.test"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
 <booleanAttribute key="clearConfig" value="true"/>
@@ -14,7 +15,7 @@
 <booleanAttribute key="includeOptional" value="true"/>
 <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/org.yakindu.sct.generator.cpp.test/test-gen/org/yakindu/sct/generator/cpp/test/AllTests.java"/>
+<listEntry value="/org.yakindu.sct.generator.c.test/test-gen/org/yakindu/sct/generator/c/test/AllTests.java"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
@@ -31,9 +32,9 @@
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.yakindu.sct.generator.cpp.test.AllTests"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.yakindu.sct.generator.c.test.AllTests"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.yakindu.sct.generator.cpp.test"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.yakindu.sct.generator.c.test"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=256m"/>
 <stringAttribute key="pde.version" value="3.3"/>

--- a/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/GTestHelper.java
+++ b/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/GTestHelper.java
@@ -38,15 +38,10 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.yakindu.sct.generator.builder.EclipseContextGeneratorExecutorLookup;
-import org.yakindu.sct.generator.core.execution.IGeneratorEntryExecutor;
+import org.yakindu.sct.generator.core.execution.GeneratorExecutorLookup;
 import org.yakindu.sct.model.sgen.GeneratorModel;
 import org.yakindu.sct.model.sgraph.Statechart;
 import org.yakindu.sct.test.models.SCTUnitTestModels;
-
-import com.google.inject.Binder;
-import com.google.inject.Module;
-import com.google.inject.name.Names;
-import com.google.inject.util.Modules;
 
 /**
  * @author Andreas Unger - Initial contribution and API
@@ -87,19 +82,11 @@ public class GTestHelper {
 
 		performFullBuild();
 
-		new EclipseContextGeneratorExecutorLookup() {
-			@Override
-			protected Module getContextModule() {
-				return Modules.override(super.getContextModule()).with(new Module() {
-					@Override
-					public void configure(Binder binder) {
-						binder.bind(boolean.class).annotatedWith(Names.named(IGeneratorEntryExecutor.SKIP_VALIDATION))
-								.toInstance(true);
-					}
-				});
-			}
+		getGeneratorExecutorLookup().execute(model);
+	}
 
-		}.execute(model);
+	protected GeneratorExecutorLookup getGeneratorExecutorLookup() {
+		return new EclipseContextGeneratorExecutorLookup();
 	}
 
 	protected String getSgenFileName(String testProgram) {


### PR DESCRIPTION
We should discuss if this is a solution. 
Actually it makes sense to skip validation for generator tests, because otherwise we would have also generator errors when we have a regression in validation for example.