### PR TITLE
Add validation for co-existing CycleBased & EventDriven

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: java
+dist: precise
 jdk: 
  - oraclejdk8
 addons:

--- a/plugins/org.yakindu.sct.model.stext/META-INF/MANIFEST.MF
+++ b/plugins/org.yakindu.sct.model.stext/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.yakindu.base.types,
  org.yakindu.base.expressions;visibility:=reexport,
  org.yakindu.sct.domain,
- org.eclipse.emf.workspace
+ org.eclipse.emf.workspace,
+ org.yakindu.sct.model.stext.lib
 Import-Package: org.apache.commons.logging,
  org.apache.log4j,
  org.eclipse.xtext.xbase.lib

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextJavaValidator.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextJavaValidator.java
@@ -11,6 +11,9 @@
  */
 package org.yakindu.sct.model.stext.validation;
 
+import static org.yakindu.sct.model.stext.lib.StatechartAnnotations.EVENT_DRIVEN_ANNOTATION;
+import static org.yakindu.sct.model.stext.lib.StatechartAnnotations.CYCLE_BASED_ANNOTATION;
+
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -45,6 +48,7 @@ import org.yakindu.base.expressions.expressions.Expression;
 import org.yakindu.base.expressions.expressions.ExpressionsPackage;
 import org.yakindu.base.expressions.expressions.FeatureCall;
 import org.yakindu.base.expressions.validation.ExpressionsJavaValidator;
+import org.yakindu.base.types.Annotation;
 import org.yakindu.base.types.Declaration;
 import org.yakindu.base.types.Direction;
 import org.yakindu.base.types.Event;
@@ -99,7 +103,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-
 /**
  * Several validations for nonsensical expressions.
  * 
@@ -427,6 +430,18 @@ public class STextJavaValidator extends AbstractSTextJavaValidator implements ST
 					}
 				}
 			}
+		}
+	}
+	
+	@Check(CheckType.FAST)
+	public void checkAnnotations(final Statechart statechart) {
+		Annotation eventDriven = statechart.getAnnotationOfType(EVENT_DRIVEN_ANNOTATION);
+		Annotation cycleBased = statechart.getAnnotationOfType(CYCLE_BASED_ANNOTATION);
+		if(eventDriven != null && cycleBased != null) {
+			String errorMsg = String.format(CONTRADICTORY_ANNOTATIONS, String.join(
+					", ", eventDriven.getType().toString(), cycleBased.getType().toString()
+					));
+			error(errorMsg, cycleBased, null, -1);
 		}
 	}
 

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextValidationMessages.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextValidationMessages.java
@@ -54,5 +54,5 @@ public interface STextValidationMessages {
 	public static final String VALUE_OF_REQUIRES_EVENT = "valueof() expression requires event as argument.";
 	public static final String IMPORT_NOT_RESOLVED_MSG = "Import '%s' cannot be resolved.";
 	public static final String IMPORT_NOT_RESOLVED_CODE = "ImportNotResolved";
-
+	public static final String CONTRADICTORY_ANNOTATIONS = "Some annotations (%s) have contradictory effects.";
 }

--- a/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/validation/STextJavaValidatorTest.java
+++ b/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/validation/STextJavaValidatorTest.java
@@ -44,6 +44,7 @@ import org.yakindu.sct.model.sgraph.State;
 import org.yakindu.sct.model.sgraph.Statechart;
 import org.yakindu.sct.model.sgraph.Transition;
 import org.yakindu.sct.model.sgraph.Trigger;
+import org.yakindu.sct.model.sgraph.impl.StatechartImpl;
 import org.yakindu.sct.model.stext.inferrer.STextTypeInferrer;
 import org.yakindu.sct.model.stext.stext.InterfaceScope;
 import org.yakindu.sct.model.stext.stext.InternalScope;
@@ -277,15 +278,14 @@ public class STextJavaValidatorTest extends AbstractSTextValidationTest implemen
 	 * @see STextJavaValidator#checkAnnotationArguments(org.yakindu.sct.model.stext.stext.AnnotationDefinition)
 	 */
 	@Test
-	@Ignore("Library Scope is not visible during tests")
 	public void checkAnnotationArguments() {
-		String scope = "@Execution()";
+		String scope = "@CycleBased";
 		EObject model = super.parseExpression(scope, StatechartSpecification.class.getSimpleName());
 		AssertableDiagnostics validationResult = tester.validate(model);
 		validationResult.assertError(STextJavaValidator.ERROR_WRONG_NUMBER_OF_ARGUMENTS_CODE);
 		;
 
-		scope = "@Execution(EVENT_DRIVEN)";
+		scope = "@EventDriven";
 		model = super.parseExpression(scope, StatechartSpecification.class.getSimpleName());
 		validationResult = tester.validate(model);
 		validationResult.assertOK();
@@ -297,6 +297,36 @@ public class STextJavaValidatorTest extends AbstractSTextValidationTest implemen
 	@Test
 	public void checkAnnotationTarget() {
 		// TODO: Implement me when default annotation for target is available
+	}
+	
+	@Test
+	public void checkAnnotations() {
+		String scope;
+		StatechartSpecification model;
+		AssertableDiagnostics validationResult;
+		
+		statechart.setName("Annotated");
+		
+		scope = "@EventDriven";
+		model = (StatechartSpecification) super.parseExpression(scope, StatechartSpecification.class.getSimpleName());
+		statechart.getAnnotations().addAll(model.getAnnotations());
+		validationResult = tester.validate(statechart);
+		validationResult.assertOK();
+		
+		scope = "@CycleBased(200)";
+		model = (StatechartSpecification) super.parseExpression(scope, StatechartSpecification.class.getSimpleName());
+		statechart.getAnnotations().clear();
+		statechart.getAnnotations().addAll(model.getAnnotations());
+		validationResult = tester.validate(statechart);
+		validationResult.assertOK();
+
+		scope = "@CycleBased(200)\n"
+				+ "@EventDriven";
+		model = (StatechartSpecification) super.parseExpression(scope, StatechartSpecification.class.getSimpleName());
+		statechart.getAnnotations().clear();
+		statechart.getAnnotations().addAll(model.getAnnotations());
+		validationResult = tester.validate(statechart);
+		validationResult.assertErrorContains(CONTRADICTORY_ANNOTATIONS.split("%s")[0]);
 	}
 
 	/**


### PR DESCRIPTION
See #1438 - but ChildFirst / ParentFirst is still missing, because those don't exist yet on master.

Looks like this - currently no way to underline the annotations was found b/c they don't "exist" in the model.
![image](https://user-images.githubusercontent.com/15799654/28622519-0997364a-7215-11e7-8540-76bcfbf62551.png)
