### PR TITLE
Change order of event code declaration in C/C++ Code-generators

### DIFF
--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/Naming.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/Naming.xtend
@@ -79,10 +79,6 @@ class Naming {
 	def typesModule(ExecutionFlow it) {
 		'sc_types'
 	}
-	
-	def eventsModule(ExecutionFlow it) {
-		'''«name»_events'''.toString
-	}
 
 	def timerType(ExecutionFlow it) {
 		'SCTimer'

--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/StatemachineHeader.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/StatemachineHeader.xtend
@@ -55,6 +55,8 @@ class StatemachineHeader implements IContentTemplate {
 		/*! \file Header of the state machine '«name»'.
 		*/
 		
+		«preStatechartDeclarations»
+		
 		«statesEnumDecl»
 		
 		«FOR s : it.scopes»
@@ -66,7 +68,7 @@ class StatemachineHeader implements IContentTemplate {
 		
 		«functions(it)»
 		
-		«additionalContents»
+		«postStatechartDeclarations»
 		
 		#ifdef __cplusplus
 		}
@@ -76,7 +78,12 @@ class StatemachineHeader implements IContentTemplate {
 	'''
 	}
 	
-	def additionalContents(ExecutionFlow it) {
+	def preStatechartDeclarations(ExecutionFlow it) {
+		/* To be implemented by child classes */
+		''''''
+	}
+	
+	def postStatechartDeclarations(ExecutionFlow it) {
 		/* To be implemented by child classes */
 		''''''
 	}

--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/EventDrivenStatemachineHeader.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/EventDrivenStatemachineHeader.xtend
@@ -34,13 +34,6 @@ class EventDrivenStatemachineHeader extends StatemachineHeader {
 		'''
 	}
 	
-	override includes(ExecutionFlow it, extension IGenArtifactConfigurations artifactConfigs) {
-		'''
-		«super.includes(it, artifactConfigs)»
-		#include "«eventsModule.h»"
-		'''
-	}
-	
 	override protected functions(ExecutionFlow it) {
 		super.functions(it).toString.replace('''const «scHandleDecl», sc_eventid evid''','''«scHandleDecl», sc_eventid evid''')
 	}

--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/EventDrivenStatemachineHeader.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/EventDrivenStatemachineHeader.xtend
@@ -19,9 +19,9 @@ class EventDrivenStatemachineHeader extends StatemachineHeader {
 	@Inject extension EventNaming
 	@Inject extension StatechartEventsHeader events
 	
-	override additionalContents(ExecutionFlow it) {
+	override preStatechartDeclarations(ExecutionFlow it) {
 		'''
-		«super.additionalContents(it)»
+		«super.preStatechartDeclarations(it)»
 		
 		«events.content(it)»
 		'''

--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineHeader.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineHeader.xtend
@@ -56,6 +56,8 @@ class StatemachineHeader extends org.yakindu.sct.generator.c.StatemachineHeader 
 			/*! \file Header of the state machine '«name»'.
 			*/
 			
+			«preStatechartDeclarations»
+			
 			/*! Define indices of states in the StateConfVector */
 			«FOR state : states»
 				#define «state.stateVectorDefine» «state.stateVector.offset»
@@ -68,7 +70,7 @@ class StatemachineHeader extends org.yakindu.sct.generator.c.StatemachineHeader 
 				«scopes.filter(typeof(StatechartScope)).map[createInlineOCB_Destructor].filterNullOrEmptyAndJoin»
 			«ENDIF»
 			
-			«additionalContents»
+			«postStatechartDeclarations»
 			
 			#endif /* «module().define»_H_ */
 		'''

--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/eventdriven/EventDrivenStatemachineHeader.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/eventdriven/EventDrivenStatemachineHeader.xtend
@@ -26,9 +26,9 @@ class EventDrivenStatemachineHeader extends StatemachineHeader {
 	@Inject extension EventNaming
 	@Inject extension StatechartEvents events
 	
-	override additionalContents(ExecutionFlow it) {
+	override preStatechartDeclarations(ExecutionFlow it) {
 		'''
-		«super.additionalContents(it)»
+		«super.postStatechartDeclarations(it)»
 		
 		«events.content(it)»
 		'''


### PR DESCRIPTION
Also, changed "additionalContents" to "postStatechartDeclaration" and
introduced "preStatechartDeclaration".

@terfloth Note renamed functions in C Header class.