### PR TITLE
This fix disposes old refreshlisteners before creating new ones

### DIFF
--- a/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/view/AbstractDebugTargetView.java
+++ b/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/view/AbstractDebugTargetView.java
@@ -88,6 +88,9 @@ public abstract class AbstractDebugTargetView extends ViewPart
 			} else {
 				newTarget = (IDebugTarget) object.getAdapter(IDebugTarget.class);
 			}
+			if(newTarget == debugTarget) {
+				return;
+			}
 			if (newTarget != debugTarget && newTarget != null && !newTarget.isTerminated()) {
 				debugTarget = newTarget;
 				activeTargetChanged(newTarget);

--- a/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/view/ExecutionContextContentProvider.java
+++ b/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/view/ExecutionContextContentProvider.java
@@ -49,7 +49,6 @@ public class ExecutionContextContentProvider implements ITreeContentProvider, IP
 					e.printStackTrace();
 				}
 			}
-
 		}
 
 		public boolean isCancel() {
@@ -78,6 +77,9 @@ public class ExecutionContextContentProvider implements ITreeContentProvider, IP
 
 	public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
 		this.viewer = viewer;
+		if (refresher != null) {
+			refresher.cancel = true;
+		}
 		refresher = new ViewerRefresher();
 		if (newInput != null) {
 			new Thread(refresher).start();


### PR DESCRIPTION
to avoid multiple UI update threads during single stepping.

Also avoid updating the active target context when the context is the
same as before.