### PR TITLE
refactored xtext gmf/jface utils to ease extensibility (no semantic change)

### DIFF
--- a/plugins/org.yakindu.base.xtext.utils.gmf/src/org/yakindu/base/xtext/utils/gmf/viewers/XtextStyledTextCellEditorEx.java
+++ b/plugins/org.yakindu.base.xtext.utils.gmf/src/org/yakindu/base/xtext/utils/gmf/viewers/XtextStyledTextCellEditorEx.java
@@ -47,18 +47,18 @@ public class XtextStyledTextCellEditorEx extends XtextStyledTextCellEditor {
 	 *            Value to set the cell editor to.
 	 * 
 	 *            Note: This happens address defect RATLC00522324. For our
-	 *            topgraphical edit parts we delagate the direct edit request to
+	 *            topgraphical edit parts we delegate the direct edit request to
 	 *            a primary edit part and set focus on that. The issue is that
 	 *            if the user has typed in an initial character when setting
 	 *            focus to the edit part, which typically is a
-	 *            TextCompartmentEditPart then setting that intial value does
+	 *            TextCompartmentEditPart then setting that initial value does
 	 *            not fire the necessary change events that need to occur in
-	 *            order for that value to be recongnized. If you don't use this
+	 *            order for that value to be recognized. If you don't use this
 	 *            method then the result is that if you just type in the initial
 	 *            character and that is it then the text compartment loses focus
 	 *            then the value will not be saved. This is because setting the
 	 *            value of the cell doesn't think its value has changed since
-	 *            the first character is not recongized as a change.
+	 *            the first character is not recognized as a change.
 	 */
 	public void setValueAndProcessEditOccured(Object value) {
 		setValue(value);

--- a/plugins/org.yakindu.base.xtext.utils.jface/src/org/yakindu/base/xtext/utils/jface/viewers/XtextSourceViewerEx.java
+++ b/plugins/org.yakindu.base.xtext.utils.jface/src/org/yakindu/base/xtext/utils/jface/viewers/XtextSourceViewerEx.java
@@ -30,7 +30,7 @@ import org.eclipse.xtext.ui.editor.XtextSourceViewer;
  * @author alexander.nyssen@itemis.de
  * 
  */
-class XtextSourceViewerEx extends XtextSourceViewer {
+public class XtextSourceViewerEx extends XtextSourceViewer {
 
 	private final StyledText styledText;
 	private final IPreferenceStore preferenceStore;
@@ -53,7 +53,7 @@ class XtextSourceViewerEx extends XtextSourceViewer {
 
 	@Override
 	protected StyledText createTextWidget(Composite parent, int styles) {
-		return styledText;
+		return this.styledText;
 	}
 
 	/**
@@ -99,7 +99,7 @@ class XtextSourceViewerEx extends XtextSourceViewer {
 			declaredField = TextSourceViewerConfiguration.class
 					.getDeclaredField("fPreferenceStore");
 			declaredField.setAccessible(true);
-			declaredField.set(configuration, preferenceStore);
+			declaredField.set(configuration, this.preferenceStore);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -112,7 +112,7 @@ class XtextSourceViewerEx extends XtextSourceViewer {
 	 * @param value
 	 *            the new value.
 	 */
-	private void setPrivateHandleProjectionChangesField(boolean value) {
+	protected void setPrivateHandleProjectionChangesField(boolean value) {
 		try {
 			Field declaredField = ProjectionViewer.class
 					.getDeclaredField("fHandleProjectionChanges");

--- a/plugins/org.yakindu.base.xtext.utils.jface/src/org/yakindu/base/xtext/utils/jface/viewers/util/ActiveEditorTracker.java
+++ b/plugins/org.yakindu.base.xtext.utils.jface/src/org/yakindu/base/xtext/utils/jface/viewers/util/ActiveEditorTracker.java
@@ -15,6 +15,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.emf.common.ui.URIEditorInput;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.edit.domain.IEditingDomainProvider;
@@ -150,6 +153,15 @@ public class ActiveEditorTracker implements IPageListener, IPartListener,
 		if (editorInput instanceof IFileEditorInput) {
 			final IFileEditorInput input = (IFileEditorInput) editorInput;
 			return input.getFile().getProject();
+		} else if (editorInput instanceof URIEditorInput) {
+			final URI uri = ((URIEditorInput) editorInput).getURI();
+			if (uri.isPlatformResource()) {
+				final String segment = uri.segment(1);
+				final IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(segment);
+				if (project.exists()) {
+					return project;
+				}
+			}
 		}
 		return null;
 	}

--- a/plugins/org.yakindu.base.xtext.utils.jface/src/org/yakindu/base/xtext/utils/jface/viewers/util/ActiveEditorTracker.java
+++ b/plugins/org.yakindu.base.xtext.utils.jface/src/org/yakindu/base/xtext/utils/jface/viewers/util/ActiveEditorTracker.java
@@ -156,11 +156,8 @@ public class ActiveEditorTracker implements IPageListener, IPartListener,
 		} else if (editorInput instanceof URIEditorInput) {
 			final URI uri = ((URIEditorInput) editorInput).getURI();
 			if (uri.isPlatformResource()) {
-				final String segment = uri.segment(1);
-				final IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(segment);
-				if (project.exists()) {
-					return project;
-				}
+				final String platformString = uri.toPlatformString(true);
+				return ResourcesPlugin.getWorkspace().getRoot().findMember(platformString).getProject();
 			}
 		}
 		return null;


### PR DESCRIPTION
This pull request just refactors the code in **org.yakindu.base.xtext.utils.gmf** and **org.yakindu.base.xtext.utils.jface** for enhanced extensibility:
* Introduces / extends creator methods
* Introduces protected getters for private fields
* Changes access to private fields to use getters
* Some fixed typos

This should not introduce any semantic change.