### PR TITLE
Rename parameter in setTimer from timer to timerInterface - fix #1612

### DIFF
--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineHeader.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineHeader.xtend
@@ -303,7 +303,7 @@ class StatemachineHeader extends org.yakindu.sct.generator.c.StatemachineHeader 
 		/*
 		 * Functions inherited from TimedStatemachineInterface
 		 */
-		virtual void setTimer(«timerInterface»* timer);
+		virtual void setTimer(«timerInterface»* timerInterface);
 		
 		virtual «timerInterface»* getTimer();
 		

--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineImplementation.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/StatemachineImplementation.xtend
@@ -213,7 +213,7 @@ class StatemachineImplementation implements IContentTemplate {
 			switch (stateConfVector[stateConfVectorPosition])
 			{
 			«FOR state : states»
-				«IF state.reactSequence!=null»
+				«IF state.reactSequence !== null»
 				case «state.shortName.asEscapedIdentifier» :
 				{
 					«state.reactSequence.shortName»();
@@ -231,9 +231,9 @@ class StatemachineImplementation implements IContentTemplate {
 	def timedStatemachineFunctions(ExecutionFlow it) '''
 		«IF timed»
 			
-			void «module»::setTimer(«timerInterface»* timer)
+			void «module»::setTimer(«timerInterface»* timerInterface)
 			{
-				this->«timerInstance» = timer;
+				this->«timerInstance» = timerInterface;
 			}
 			
 			«timerInterface»* «module»::getTimer()

--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/TimedStatemachineInterface.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/TimedStatemachineInterface.xtend
@@ -45,7 +45,7 @@ class TimedStatemachineInterface implements IContentTemplate {
 				    externally on a timed state machine before a run cycle can be correct
 				    executed.
 				*/
-				virtual void setTimer(«timerInterface»* timer) = 0;
+				virtual void setTimer(«timerInterface»* timerInterface) = 0;
 				
 				/*! Returns the currently used timer service.
 				*/


### PR DESCRIPTION
With `-Wshadow` gcc complained about the member `TimerInterface * timer` being shadowed by the setter parameter `TimerInterface * timer`. This was no real issue of course, because the member variable is referenced with `this->timer`, but it was easy to fix with renaming the parameter from `timer` to `timerInterface`.

Fixes #1612