### PR TITLE
fix EMF Compare preference labels

### DIFF
--- a/plugins/org.yakindu.sct.compare/plugin.xml
+++ b/plugins/org.yakindu.sct.compare/plugin.xml
@@ -12,6 +12,8 @@
          point="org.eclipse.emf.compare.rcp.matchEngine">
       <engineFactory
             class="org.yakindu.sct.compare.match.SCTMatchEngineFactory"
+            description="This match engine ignores transient elements in state charts."
+            label="State Chart Match Engine"
             ranking="11">
       </engineFactory>
    </extension>
@@ -19,6 +21,8 @@
          point="org.eclipse.emf.compare.rcp.postProcessor">
       <processor
             class="org.yakindu.sct.compare.postprocessor.EdgeChangePostProcessor"
+            description="This post processor improves difference results for edge changes between state chart states."
+            label="State Chart Edge Change Post Processor"
             ordinal="100">
          <nsURI
                value="http://www.eclipse.org/gmf/runtime/\d.\d.\d/notation">
@@ -29,8 +33,10 @@
          point="org.eclipse.emf.compare.edit.adapterFactory">
       <factory
             class="org.yakindu.sct.compare.labelprovider.SCTCompareAdapterFactory"
-              supportedTypes="org.eclipse.emf.edit.provider.IItemLabelProvider"
+            description="This label provider removes line breaks from state chart item labels."
+            label="State Chart Item Label Provider"
             ranking="11"
+            supportedTypes="org.eclipse.emf.edit.provider.IItemLabelProvider"
             uri="http://www.eclipse.org/emf/compare">
       </factory>
 </extension>

--- a/plugins/org.yakindu.sct.compare/plugin.xml
+++ b/plugins/org.yakindu.sct.compare/plugin.xml
@@ -12,8 +12,8 @@
          point="org.eclipse.emf.compare.rcp.matchEngine">
       <engineFactory
             class="org.yakindu.sct.compare.match.SCTMatchEngineFactory"
-            description="This match engine ignores transient elements in state charts."
-            label="State Chart Match Engine"
+            description="This match engine ignores transient elements in statecharts."
+            label="Statechart Match Engine"
             ranking="11">
       </engineFactory>
    </extension>
@@ -21,8 +21,8 @@
          point="org.eclipse.emf.compare.rcp.postProcessor">
       <processor
             class="org.yakindu.sct.compare.postprocessor.EdgeChangePostProcessor"
-            description="This post processor improves difference results for edge changes between state chart states."
-            label="State Chart Edge Change Post Processor"
+            description="This post processor improves difference results for edge changes between statechart states."
+            label="Statechart Edge Change Post Processor"
             ordinal="100">
          <nsURI
                value="http://www.eclipse.org/gmf/runtime/\d.\d.\d/notation">
@@ -33,8 +33,8 @@
          point="org.eclipse.emf.compare.edit.adapterFactory">
       <factory
             class="org.yakindu.sct.compare.labelprovider.SCTCompareAdapterFactory"
-            description="This label provider removes line breaks from state chart item labels."
-            label="State Chart Item Label Provider"
+            description="This label provider removes line breaks from statechart item labels."
+            label="Statechart Item Label Provider"
             ranking="11"
             supportedTypes="org.eclipse.emf.edit.provider.IItemLabelProvider"
             uri="http://www.eclipse.org/emf/compare">


### PR DESCRIPTION
The custom processors for EMF Compare all need a label, otherwise the
class names are displayed in the preference pages.

Feel free to change the wording.