### PR TITLE
Fixes #1751 where rename refactorings on interfaces lead to …

### DIFF
--- a/plugins/org.yakindu.sct.model.sgraph/model/emf/sgraph.ecore
+++ b/plugins/org.yakindu.sct.model.sgraph/model/emf/sgraph.ecore
@@ -70,7 +70,7 @@
         upperBound="-1" eType="ecore:EClass ../../../org.yakindu.base.types/model/types.ecore#//Property"
         changeable="false" volatile="true" transient="true" derived="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="reactions" upperBound="-1"
-        eType="#//Reaction" changeable="false" volatile="true" transient="true"/>
+        eType="#//Reaction" changeable="false" volatile="true" transient="true" derived="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="members" upperBound="-1"
         eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject" containment="true"/>
   </eClassifiers>

--- a/plugins/org.yakindu.sct.model.sgraph/model/emf/sgraph.ecore
+++ b/plugins/org.yakindu.sct.model.sgraph/model/emf/sgraph.ecore
@@ -62,7 +62,7 @@
   <eClassifiers xsi:type="ecore:EClass" name="Scope">
     <eStructuralFeatures xsi:type="ecore:EReference" name="declarations" upperBound="-1"
         eType="ecore:EClass ../../../org.yakindu.base.types/model/types.ecore#//Declaration"
-        containment="true"/>
+        changeable="false" volatile="true" transient="true" derived="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="events" upperBound="-1"
         eType="ecore:EClass ../../../org.yakindu.base.types/model/types.ecore#//Event"
         changeable="false" volatile="true" transient="true" derived="true"/>
@@ -70,7 +70,9 @@
         upperBound="-1" eType="ecore:EClass ../../../org.yakindu.base.types/model/types.ecore#//Property"
         changeable="false" volatile="true" transient="true" derived="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="reactions" upperBound="-1"
-        eType="#//Reaction" containment="true"/>
+        eType="#//Reaction" changeable="false" volatile="true" transient="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="members" upperBound="-1"
+        eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ScopedElement" abstract="true">
     <eStructuralFeatures xsi:type="ecore:EReference" name="scopes" upperBound="-1"
@@ -100,4 +102,5 @@
   <eClassifiers xsi:type="ecore:EClass" name="ImportDeclaration" eSuperTypes="../../../org.yakindu.base.types/model/types.ecore#//Declaration">
     <eStructuralFeatures xsi:type="ecore:EReference" name="declaration" eType="ecore:EClass ../../../org.yakindu.base.types/model/types.ecore#//Declaration"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ScopeMember"/>
 </ecore:EPackage>

--- a/plugins/org.yakindu.sct.model.sgraph/model/emf/sgraph.genmodel
+++ b/plugins/org.yakindu.sct.model.sgraph/model/emf/sgraph.genmodel
@@ -35,15 +35,13 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sgraph.ecore#//Choice/kind"/>
     </genClasses>
     <genClasses ecoreClass="sgraph.ecore#//Statechart">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference sgraph.ecore#//Statechart/imports"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sgraph.ecore#//Statechart/domainID"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference sgraph.ecore#//Statechart/annotations"/>
     </genClasses>
     <genClasses ecoreClass="sgraph.ecore#//Entry">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sgraph.ecore#//Entry/kind"/>
     </genClasses>
     <genClasses ecoreClass="sgraph.ecore#//Exit"/>
     <genClasses image="false" ecoreClass="sgraph.ecore#//ReactiveElement">
-      <genFeatures property="Readonly" notify="false" createChild="false" ecoreFeature="ecore:EReference sgraph.ecore#//ReactiveElement/reactions"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference sgraph.ecore#//ReactiveElement/localReactions"/>
     </genClasses>
     <genClasses image="false" ecoreClass="sgraph.ecore#//Reaction">
@@ -61,6 +59,8 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference sgraph.ecore#//Scope/declarations"/>
       <genFeatures property="Readonly" notify="false" createChild="false" ecoreFeature="ecore:EReference sgraph.ecore#//Scope/events"/>
       <genFeatures property="Readonly" notify="false" createChild="false" ecoreFeature="ecore:EReference sgraph.ecore#//Scope/variables"/>
+      <genFeatures property="None" children="true" createChild="false" ecoreFeature="ecore:EReference sgraph.ecore#//Scope/reactions"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference sgraph.ecore#//Scope/members"/>
     </genClasses>
     <genClasses image="false" ecoreClass="sgraph.ecore#//ScopedElement">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference sgraph.ecore#//ScopedElement/scopes"/>
@@ -69,9 +69,6 @@
     <genClasses ecoreClass="sgraph.ecore#//Synchronization"/>
     <genClasses ecoreClass="sgraph.ecore#//State">
       <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute sgraph.ecore#//State/orthogonal"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference sgraph.ecore#//State/substatechart"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sgraph.ecore#//State/substatechartId"/>
-      <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute sgraph.ecore#//State/subchart"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sgraph.ecore#//State/simple"/>
       <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute sgraph.ecore#//State/composite"/>
       <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute sgraph.ecore#//State/leaf"/>
@@ -80,11 +77,9 @@
     <genClasses image="false" ecoreClass="sgraph.ecore#//CompositeElement">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference sgraph.ecore#//CompositeElement/regions"/>
     </genClasses>
-    <genClasses ecoreClass="sgraph.ecore#//Import">
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sgraph.ecore#//Import/importedNamespace"/>
-    </genClasses>
     <genClasses ecoreClass="sgraph.ecore#//ImportDeclaration">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference sgraph.ecore#//ImportDeclaration/declaration"/>
     </genClasses>
+    <genClasses ecoreClass="sgraph.ecore#//ScopeMember"/>
   </genPackages>
 </genmodel:GenModel>

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/SGraphFactory.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/SGraphFactory.java
@@ -145,6 +145,15 @@ public interface SGraphFactory extends EFactory {
 	ImportDeclaration createImportDeclaration();
 
 	/**
+	 * Returns a new object of class '<em>Scope Member</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>Scope Member</em>'.
+	 * @generated
+	 */
+	ScopeMember createScopeMember();
+
+	/**
 	 * Returns the package supported by this factory.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/SGraphPackage.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/SGraphPackage.java
@@ -884,7 +884,7 @@ public interface SGraphPackage extends EPackage {
 	int SCOPE = 15;
 
 	/**
-	 * The feature id for the '<em><b>Declarations</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Declarations</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -911,7 +911,7 @@ public interface SGraphPackage extends EPackage {
 	int SCOPE__VARIABLES = 2;
 
 	/**
-	 * The feature id for the '<em><b>Reactions</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Reactions</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -920,13 +920,22 @@ public interface SGraphPackage extends EPackage {
 	int SCOPE__REACTIONS = 3;
 
 	/**
+	 * The feature id for the '<em><b>Members</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SCOPE__MEMBERS = 4;
+
+	/**
 	 * The number of structural features of the '<em>Scope</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int SCOPE_FEATURE_COUNT = 4;
+	int SCOPE_FEATURE_COUNT = 5;
 
 	/**
 	 * The meta object id for the '{@link org.yakindu.sct.model.sgraph.impl.ScopedElementImpl <em>Scoped Element</em>}' class.
@@ -1257,6 +1266,25 @@ public interface SGraphPackage extends EPackage {
 	int IMPORT_DECLARATION_FEATURE_COUNT = TypesPackage.DECLARATION_FEATURE_COUNT + 1;
 
 	/**
+	 * The meta object id for the '{@link org.yakindu.sct.model.sgraph.impl.ScopeMemberImpl <em>Scope Member</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.yakindu.sct.model.sgraph.impl.ScopeMemberImpl
+	 * @see org.yakindu.sct.model.sgraph.impl.SGraphPackageImpl#getScopeMember()
+	 * @generated
+	 */
+	int SCOPE_MEMBER = 22;
+
+	/**
+	 * The number of structural features of the '<em>Scope Member</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SCOPE_MEMBER_FEATURE_COUNT = 0;
+
+	/**
 	 * The meta object id for the '{@link org.yakindu.sct.model.sgraph.EntryKind <em>Entry Kind</em>}' enum.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1264,7 +1292,7 @@ public interface SGraphPackage extends EPackage {
 	 * @see org.yakindu.sct.model.sgraph.impl.SGraphPackageImpl#getEntryKind()
 	 * @generated
 	 */
-	int ENTRY_KIND = 22;
+	int ENTRY_KIND = 23;
 
 
 	/**
@@ -1275,7 +1303,7 @@ public interface SGraphPackage extends EPackage {
 	 * @see org.yakindu.sct.model.sgraph.impl.SGraphPackageImpl#getChoiceKind()
 	 * @generated
 	 */
-	int CHOICE_KIND = 23;
+	int CHOICE_KIND = 24;
 
 
 	/**
@@ -1512,6 +1540,16 @@ public interface SGraphPackage extends EPackage {
 	EReference getImportDeclaration_Declaration();
 
 	/**
+	 * Returns the meta object for class '{@link org.yakindu.sct.model.sgraph.ScopeMember <em>Scope Member</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Scope Member</em>'.
+	 * @see org.yakindu.sct.model.sgraph.ScopeMember
+	 * @generated
+	 */
+	EClass getScopeMember();
+
+	/**
 	 * Returns the meta object for class '{@link org.yakindu.sct.model.sgraph.Choice <em>Choice</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1710,10 +1748,10 @@ public interface SGraphPackage extends EPackage {
 	EClass getScope();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link org.yakindu.sct.model.sgraph.Scope#getDeclarations <em>Declarations</em>}'.
+	 * Returns the meta object for the reference list '{@link org.yakindu.sct.model.sgraph.Scope#getDeclarations <em>Declarations</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Declarations</em>'.
+	 * @return the meta object for the reference list '<em>Declarations</em>'.
 	 * @see org.yakindu.sct.model.sgraph.Scope#getDeclarations()
 	 * @see #getScope()
 	 * @generated
@@ -1743,15 +1781,26 @@ public interface SGraphPackage extends EPackage {
 	EReference getScope_Variables();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link org.yakindu.sct.model.sgraph.Scope#getReactions <em>Reactions</em>}'.
+	 * Returns the meta object for the reference list '{@link org.yakindu.sct.model.sgraph.Scope#getReactions <em>Reactions</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Reactions</em>'.
+	 * @return the meta object for the reference list '<em>Reactions</em>'.
 	 * @see org.yakindu.sct.model.sgraph.Scope#getReactions()
 	 * @see #getScope()
 	 * @generated
 	 */
 	EReference getScope_Reactions();
+
+	/**
+	 * Returns the meta object for the containment reference list '{@link org.yakindu.sct.model.sgraph.Scope#getMembers <em>Members</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the containment reference list '<em>Members</em>'.
+	 * @see org.yakindu.sct.model.sgraph.Scope#getMembers()
+	 * @see #getScope()
+	 * @generated
+	 */
+	EReference getScope_Members();
 
 	/**
 	 * Returns the meta object for class '{@link org.yakindu.sct.model.sgraph.ScopedElement <em>Scoped Element</em>}'.
@@ -2032,6 +2081,16 @@ public interface SGraphPackage extends EPackage {
 		EReference IMPORT_DECLARATION__DECLARATION = eINSTANCE.getImportDeclaration_Declaration();
 
 		/**
+		 * The meta object literal for the '{@link org.yakindu.sct.model.sgraph.impl.ScopeMemberImpl <em>Scope Member</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.yakindu.sct.model.sgraph.impl.ScopeMemberImpl
+		 * @see org.yakindu.sct.model.sgraph.impl.SGraphPackageImpl#getScopeMember()
+		 * @generated
+		 */
+		EClass SCOPE_MEMBER = eINSTANCE.getScopeMember();
+
+		/**
 		 * The meta object literal for the '{@link org.yakindu.sct.model.sgraph.impl.ChoiceImpl <em>Choice</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
@@ -2206,7 +2265,7 @@ public interface SGraphPackage extends EPackage {
 		EClass SCOPE = eINSTANCE.getScope();
 
 		/**
-		 * The meta object literal for the '<em><b>Declarations</b></em>' containment reference list feature.
+		 * The meta object literal for the '<em><b>Declarations</b></em>' reference list feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
 		 * @generated
@@ -2230,12 +2289,20 @@ public interface SGraphPackage extends EPackage {
 		EReference SCOPE__VARIABLES = eINSTANCE.getScope_Variables();
 
 		/**
-		 * The meta object literal for the '<em><b>Reactions</b></em>' containment reference list feature.
+		 * The meta object literal for the '<em><b>Reactions</b></em>' reference list feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
 		 * @generated
 		 */
 		EReference SCOPE__REACTIONS = eINSTANCE.getScope_Reactions();
+
+		/**
+		 * The meta object literal for the '<em><b>Members</b></em>' containment reference list feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EReference SCOPE__MEMBERS = eINSTANCE.getScope_Members();
 
 		/**
 		 * The meta object literal for the '{@link org.yakindu.sct.model.sgraph.impl.ScopedElementImpl <em>Scoped Element</em>}' class.

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/Scope.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/Scope.java
@@ -29,6 +29,7 @@ import org.yakindu.base.types.Property;
  *   <li>{@link org.yakindu.sct.model.sgraph.Scope#getEvents <em>Events</em>}</li>
  *   <li>{@link org.yakindu.sct.model.sgraph.Scope#getVariables <em>Variables</em>}</li>
  *   <li>{@link org.yakindu.sct.model.sgraph.Scope#getReactions <em>Reactions</em>}</li>
+ *   <li>{@link org.yakindu.sct.model.sgraph.Scope#getMembers <em>Members</em>}</li>
  * </ul>
  *
  * @see org.yakindu.sct.model.sgraph.SGraphPackage#getScope()
@@ -44,7 +45,7 @@ public interface Scope extends EObject {
 	String copyright = "Copyright (c) 2011 committers of YAKINDU and others.\r\nAll rights reserved. This program and the accompanying materials\r\nare made available under the terms of the Eclipse Public License v1.0\r\nwhich accompanies this distribution, and is available at\r\nhttp://www.eclipse.org/legal/epl-v10.html\r\nContributors:\r\ncommitters of YAKINDU - initial API and implementation\r\n";
 
 	/**
-	 * Returns the value of the '<em><b>Declarations</b></em>' containment reference list.
+	 * Returns the value of the '<em><b>Declarations</b></em>' reference list.
 	 * The list contents are of type {@link org.yakindu.base.types.Declaration}.
 	 * <!-- begin-user-doc -->
 	 * <p>
@@ -52,9 +53,9 @@ public interface Scope extends EObject {
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Declarations</em>' containment reference list.
+	 * @return the value of the '<em>Declarations</em>' reference list.
 	 * @see org.yakindu.sct.model.sgraph.SGraphPackage#getScope_Declarations()
-	 * @model containment="true" resolveProxies="true"
+	 * @model transient="true" changeable="false" volatile="true" derived="true"
 	 * @generated
 	 */
 	EList<Declaration> getDeclarations();
@@ -92,7 +93,7 @@ public interface Scope extends EObject {
 	EList<Property> getVariables();
 
 	/**
-	 * Returns the value of the '<em><b>Reactions</b></em>' containment reference list.
+	 * Returns the value of the '<em><b>Reactions</b></em>' reference list.
 	 * The list contents are of type {@link org.yakindu.sct.model.sgraph.Reaction}.
 	 * <!-- begin-user-doc -->
 	 * <p>
@@ -100,11 +101,27 @@ public interface Scope extends EObject {
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Reactions</em>' containment reference list.
+	 * @return the value of the '<em>Reactions</em>' reference list.
 	 * @see org.yakindu.sct.model.sgraph.SGraphPackage#getScope_Reactions()
-	 * @model containment="true" resolveProxies="true"
+	 * @model transient="true" changeable="false" volatile="true"
 	 * @generated
 	 */
 	EList<Reaction> getReactions();
+
+	/**
+	 * Returns the value of the '<em><b>Members</b></em>' containment reference list.
+	 * The list contents are of type {@link org.eclipse.emf.ecore.EObject}.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Members</em>' containment reference list isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Members</em>' containment reference list.
+	 * @see org.yakindu.sct.model.sgraph.SGraphPackage#getScope_Members()
+	 * @model containment="true" resolveProxies="true"
+	 * @generated
+	 */
+	EList<EObject> getMembers();
 
 } // Scope

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/Scope.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/Scope.java
@@ -103,7 +103,7 @@ public interface Scope extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Reactions</em>' reference list.
 	 * @see org.yakindu.sct.model.sgraph.SGraphPackage#getScope_Reactions()
-	 * @model transient="true" changeable="false" volatile="true"
+	 * @model transient="true" changeable="false" volatile="true" derived="true"
 	 * @generated
 	 */
 	EList<Reaction> getReactions();

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/ScopeMember.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/ScopeMember.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2011 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ * 
+ */
+package org.yakindu.sct.model.sgraph;
+
+import org.eclipse.emf.ecore.EObject;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Scope Member</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ *
+ * @see org.yakindu.sct.model.sgraph.SGraphPackage#getScopeMember()
+ * @model
+ * @generated
+ */
+public interface ScopeMember extends EObject {
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	String copyright = "Copyright (c) 2011 committers of YAKINDU and others.\r\nAll rights reserved. This program and the accompanying materials\r\nare made available under the terms of the Eclipse Public License v1.0\r\nwhich accompanies this distribution, and is available at\r\nhttp://www.eclipse.org/legal/epl-v10.html\r\nContributors:\r\ncommitters of YAKINDU - initial API and implementation\r\n";
+
+} // ScopeMember

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/impl/SGraphFactoryImpl.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/impl/SGraphFactoryImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.impl.EFactoryImpl;
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
+import org.yakindu.sct.model.sgraph.*;
 import org.yakindu.sct.model.sgraph.Choice;
 import org.yakindu.sct.model.sgraph.ChoiceKind;
 import org.yakindu.sct.model.sgraph.Entry;
@@ -96,6 +97,7 @@ public class SGraphFactoryImpl extends EFactoryImpl implements SGraphFactory {
 			case SGraphPackage.SYNCHRONIZATION: return createSynchronization();
 			case SGraphPackage.STATE: return createState();
 			case SGraphPackage.IMPORT_DECLARATION: return createImportDeclaration();
+			case SGraphPackage.SCOPE_MEMBER: return createScopeMember();
 			default:
 				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
 		}
@@ -253,6 +255,16 @@ public class SGraphFactoryImpl extends EFactoryImpl implements SGraphFactory {
 	public ImportDeclaration createImportDeclaration() {
 		ImportDeclarationImpl importDeclaration = new ImportDeclarationImpl();
 		return importDeclaration;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public ScopeMember createScopeMember() {
+		ScopeMemberImpl scopeMember = new ScopeMemberImpl();
+		return scopeMember;
 	}
 
 	/**

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/impl/SGraphPackageImpl.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/impl/SGraphPackageImpl.java
@@ -36,6 +36,7 @@ import org.yakindu.sct.model.sgraph.RegularState;
 import org.yakindu.sct.model.sgraph.SGraphFactory;
 import org.yakindu.sct.model.sgraph.SGraphPackage;
 import org.yakindu.sct.model.sgraph.Scope;
+import org.yakindu.sct.model.sgraph.ScopeMember;
 import org.yakindu.sct.model.sgraph.ScopedElement;
 import org.yakindu.sct.model.sgraph.SpecificationElement;
 import org.yakindu.sct.model.sgraph.State;
@@ -121,6 +122,13 @@ public class SGraphPackageImpl extends EPackageImpl implements SGraphPackage {
 	 * @generated
 	 */
 	private EClass importDeclarationEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass scopeMemberEClass = null;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -274,6 +282,7 @@ public class SGraphPackageImpl extends EPackageImpl implements SGraphPackage {
 		isInited = true;
 
 		// Initialize simple dependencies
+		BasePackage.eINSTANCE.eClass();
 		TypesPackage.eINSTANCE.eClass();
 
 		// Create package meta-data objects
@@ -494,6 +503,15 @@ public class SGraphPackageImpl extends EPackageImpl implements SGraphPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EClass getScopeMember() {
+		return scopeMemberEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EClass getChoice() {
 		return choiceEClass;
 	}
@@ -701,6 +719,15 @@ public class SGraphPackageImpl extends EPackageImpl implements SGraphPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EReference getScope_Members() {
+		return (EReference)scopeEClass.getEStructuralFeatures().get(4);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EClass getScopedElement() {
 		return scopedElementEClass;
 	}
@@ -828,6 +855,7 @@ public class SGraphPackageImpl extends EPackageImpl implements SGraphPackage {
 		createEReference(scopeEClass, SCOPE__EVENTS);
 		createEReference(scopeEClass, SCOPE__VARIABLES);
 		createEReference(scopeEClass, SCOPE__REACTIONS);
+		createEReference(scopeEClass, SCOPE__MEMBERS);
 
 		scopedElementEClass = createEClass(SCOPED_ELEMENT);
 		createEReference(scopedElementEClass, SCOPED_ELEMENT__SCOPES);
@@ -848,6 +876,8 @@ public class SGraphPackageImpl extends EPackageImpl implements SGraphPackage {
 
 		importDeclarationEClass = createEClass(IMPORT_DECLARATION);
 		createEReference(importDeclarationEClass, IMPORT_DECLARATION__DECLARATION);
+
+		scopeMemberEClass = createEClass(SCOPE_MEMBER);
 
 		// Create enums
 		entryKindEEnum = createEEnum(ENTRY_KIND);
@@ -961,10 +991,11 @@ public class SGraphPackageImpl extends EPackageImpl implements SGraphPackage {
 		initEAttribute(getSpecificationElement_Specification(), ecorePackage.getEString(), "specification", null, 0, 1, SpecificationElement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(scopeEClass, Scope.class, "Scope", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getScope_Declarations(), theTypesPackage.getDeclaration(), null, "declarations", null, 0, -1, Scope.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getScope_Declarations(), theTypesPackage.getDeclaration(), null, "declarations", null, 0, -1, Scope.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 		initEReference(getScope_Events(), theTypesPackage.getEvent(), null, "events", null, 0, -1, Scope.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 		initEReference(getScope_Variables(), theTypesPackage.getProperty(), null, "variables", null, 0, -1, Scope.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-		initEReference(getScope_Reactions(), this.getReaction(), null, "reactions", null, 0, -1, Scope.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getScope_Reactions(), this.getReaction(), null, "reactions", null, 0, -1, Scope.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getScope_Members(), ecorePackage.getEObject(), null, "members", null, 0, -1, Scope.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(scopedElementEClass, ScopedElement.class, "ScopedElement", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getScopedElement_Scopes(), this.getScope(), null, "scopes", null, 0, -1, ScopedElement.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -985,6 +1016,8 @@ public class SGraphPackageImpl extends EPackageImpl implements SGraphPackage {
 
 		initEClass(importDeclarationEClass, ImportDeclaration.class, "ImportDeclaration", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getImportDeclaration_Declaration(), theTypesPackage.getDeclaration(), null, "declaration", null, 0, 1, ImportDeclaration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(scopeMemberEClass, ScopeMember.class, "ScopeMember", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
 		// Initialize enums and add enum literals
 		initEEnum(entryKindEEnum, EntryKind.class, "EntryKind");

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/impl/ScopeImpl.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/impl/ScopeImpl.java
@@ -11,10 +11,10 @@
 package org.yakindu.sct.model.sgraph.impl;
 
 import java.util.Collection;
-
 import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.EObjectImpl;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
@@ -38,6 +38,7 @@ import org.yakindu.sct.model.sgraph.util.DerivedSubsetEObjectEList;
  *   <li>{@link org.yakindu.sct.model.sgraph.impl.ScopeImpl#getEvents <em>Events</em>}</li>
  *   <li>{@link org.yakindu.sct.model.sgraph.impl.ScopeImpl#getVariables <em>Variables</em>}</li>
  *   <li>{@link org.yakindu.sct.model.sgraph.impl.ScopeImpl#getReactions <em>Reactions</em>}</li>
+ *   <li>{@link org.yakindu.sct.model.sgraph.impl.ScopeImpl#getMembers <em>Members</em>}</li>
  * </ul>
  *
  * @generated
@@ -50,25 +51,14 @@ public class ScopeImpl extends EObjectImpl implements Scope {
 	public static final String copyright = "Copyright (c) 2011 committers of YAKINDU and others.\r\nAll rights reserved. This program and the accompanying materials\r\nare made available under the terms of the Eclipse Public License v1.0\r\nwhich accompanies this distribution, and is available at\r\nhttp://www.eclipse.org/legal/epl-v10.html\r\nContributors:\r\ncommitters of YAKINDU - initial API and implementation\r\n";
 
 	/**
-	 * The cached value of the '{@link #getDeclarations() <em>Declarations</em>}
-	 * ' containment reference list. <!-- begin-user-doc --> <!-- end-user-doc
-	 * -->
-	 * 
-	 * @see #getDeclarations()
-	 * @generated
-	 * @ordered
-	 */
-	protected EList<Declaration> declarations;
-
-	/**
-	 * The cached value of the '{@link #getReactions() <em>Reactions</em>}' containment reference list.
+	 * The cached value of the '{@link #getMembers() <em>Members</em>}' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #getReactions()
+	 * @see #getMembers()
 	 * @generated
 	 * @ordered
 	 */
-	protected EList<Reaction> reactions;
+	protected EList<EObject> members;
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -89,13 +79,12 @@ public class ScopeImpl extends EObjectImpl implements Scope {
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * @generated
+	 * @generated NOT
 	 */
 	public EList<Declaration> getDeclarations() {
-		if (declarations == null) {
-			declarations = new EObjectContainmentEList.Resolving<Declaration>(Declaration.class, this, SGraphPackage.SCOPE__DECLARATIONS);
-		}
-		return declarations;
+		return new DerivedSubsetEObjectEList<Declaration>(Declaration.class, this,
+				SGraphPackage.SCOPE__DECLARATIONS,
+				SGraphPackage.SCOPE__MEMBERS);
 	}
 
 	/**
@@ -106,7 +95,7 @@ public class ScopeImpl extends EObjectImpl implements Scope {
 	public EList<Event> getEvents() {
 		return new DerivedSubsetEObjectEList<Event>(Event.class, this,
 				SGraphPackage.SCOPE__EVENTS,
-				SGraphPackage.SCOPE__DECLARATIONS);
+				SGraphPackage.SCOPE__MEMBERS);
 	}
 
 	/**
@@ -117,7 +106,18 @@ public class ScopeImpl extends EObjectImpl implements Scope {
 	public EList<Property> getVariables() {
 		return new DerivedSubsetEObjectEList<Property>(Property.class, this,
 				SGraphPackage.SCOPE__VARIABLES,
-				SGraphPackage.SCOPE__DECLARATIONS);
+				SGraphPackage.SCOPE__MEMBERS);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated NOT
+	 */
+	public EList<Reaction> getReactions() {
+		return new DerivedSubsetEObjectEList<Reaction>(Reaction.class, this,
+				SGraphPackage.SCOPE__REACTIONS,
+				SGraphPackage.SCOPE__MEMBERS);
 	}
 
 	/**
@@ -125,11 +125,11 @@ public class ScopeImpl extends EObjectImpl implements Scope {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EList<Reaction> getReactions() {
-		if (reactions == null) {
-			reactions = new EObjectContainmentEList.Resolving<Reaction>(Reaction.class, this, SGraphPackage.SCOPE__REACTIONS);
+	public EList<EObject> getMembers() {
+		if (members == null) {
+			members = new EObjectContainmentEList.Resolving<EObject>(EObject.class, this, SGraphPackage.SCOPE__MEMBERS);
 		}
-		return reactions;
+		return members;
 	}
 
 	/**
@@ -140,10 +140,8 @@ public class ScopeImpl extends EObjectImpl implements Scope {
 	@Override
 	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
-			case SGraphPackage.SCOPE__DECLARATIONS:
-				return ((InternalEList<?>)getDeclarations()).basicRemove(otherEnd, msgs);
-			case SGraphPackage.SCOPE__REACTIONS:
-				return ((InternalEList<?>)getReactions()).basicRemove(otherEnd, msgs);
+			case SGraphPackage.SCOPE__MEMBERS:
+				return ((InternalEList<?>)getMembers()).basicRemove(otherEnd, msgs);
 		}
 		return super.eInverseRemove(otherEnd, featureID, msgs);
 	}
@@ -163,42 +161,39 @@ public class ScopeImpl extends EObjectImpl implements Scope {
 				return getVariables();
 			case SGraphPackage.SCOPE__REACTIONS:
 				return getReactions();
+			case SGraphPackage.SCOPE__MEMBERS:
+				return getMembers();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
 
 	/**
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-			case SGraphPackage.SCOPE__DECLARATIONS:
-				getDeclarations().clear();
-				getDeclarations().addAll((Collection<? extends Declaration>)newValue);
-				return;
-			case SGraphPackage.SCOPE__REACTIONS:
-				getReactions().clear();
-				getReactions().addAll((Collection<? extends Reaction>)newValue);
+			case SGraphPackage.SCOPE__MEMBERS:
+				getMembers().clear();
+				getMembers().addAll((Collection<? extends EObject>)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
 	}
 
 	/**
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
-			case SGraphPackage.SCOPE__DECLARATIONS:
-				getDeclarations().clear();
-				return;
-			case SGraphPackage.SCOPE__REACTIONS:
-				getReactions().clear();
+			case SGraphPackage.SCOPE__MEMBERS:
+				getMembers().clear();
 				return;
 		}
 		super.eUnset(featureID);
@@ -212,13 +207,15 @@ public class ScopeImpl extends EObjectImpl implements Scope {
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
 			case SGraphPackage.SCOPE__DECLARATIONS:
-				return declarations != null && !declarations.isEmpty();
+				return !getDeclarations().isEmpty();
 			case SGraphPackage.SCOPE__EVENTS:
 				return !getEvents().isEmpty();
 			case SGraphPackage.SCOPE__VARIABLES:
 				return !getVariables().isEmpty();
 			case SGraphPackage.SCOPE__REACTIONS:
-				return reactions != null && !reactions.isEmpty();
+				return !getReactions().isEmpty();
+			case SGraphPackage.SCOPE__MEMBERS:
+				return members != null && !members.isEmpty();
 		}
 		return super.eIsSet(featureID);
 	}

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/impl/ScopeMemberImpl.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/impl/ScopeMemberImpl.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2011 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ * 
+ */
+package org.yakindu.sct.model.sgraph.impl;
+
+import org.eclipse.emf.ecore.EClass;
+
+import org.eclipse.emf.ecore.impl.EObjectImpl;
+
+import org.yakindu.sct.model.sgraph.SGraphPackage;
+import org.yakindu.sct.model.sgraph.ScopeMember;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>Scope Member</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * @generated
+ */
+public class ScopeMemberImpl extends EObjectImpl implements ScopeMember {
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static final String copyright = "Copyright (c) 2011 committers of YAKINDU and others.\r\nAll rights reserved. This program and the accompanying materials\r\nare made available under the terms of the Eclipse Public License v1.0\r\nwhich accompanies this distribution, and is available at\r\nhttp://www.eclipse.org/legal/epl-v10.html\r\nContributors:\r\ncommitters of YAKINDU - initial API and implementation\r\n";
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected ScopeMemberImpl() {
+		super();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	protected EClass eStaticClass() {
+		return SGraphPackage.Literals.SCOPE_MEMBER;
+	}
+
+} //ScopeMemberImpl

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/util/SGraphAdapterFactory.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/util/SGraphAdapterFactory.java
@@ -21,6 +21,7 @@ import org.yakindu.base.types.AnnotatableElement;
 import org.yakindu.base.types.Declaration;
 import org.yakindu.base.types.PackageMember;
 import org.yakindu.base.types.TypedElement;
+import org.yakindu.sct.model.sgraph.*;
 import org.yakindu.sct.model.sgraph.Choice;
 import org.yakindu.sct.model.sgraph.CompositeElement;
 import org.yakindu.sct.model.sgraph.Effect;
@@ -195,6 +196,10 @@ public class SGraphAdapterFactory extends AdapterFactoryImpl {
 			@Override
 			public Adapter caseImportDeclaration(ImportDeclaration object) {
 				return createImportDeclarationAdapter();
+			}
+			@Override
+			public Adapter caseScopeMember(ScopeMember object) {
+				return createScopeMemberAdapter();
 			}
 			@Override
 			public Adapter caseNamedElement(NamedElement object) {
@@ -465,6 +470,20 @@ public class SGraphAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	public Adapter createImportDeclarationAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.yakindu.sct.model.sgraph.ScopeMember <em>Scope Member</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.yakindu.sct.model.sgraph.ScopeMember
+	 * @generated
+	 */
+	public Adapter createScopeMemberAdapter() {
 		return null;
 	}
 

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/util/SGraphSwitch.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/util/SGraphSwitch.java
@@ -20,6 +20,7 @@ import org.yakindu.base.types.AnnotatableElement;
 import org.yakindu.base.types.Declaration;
 import org.yakindu.base.types.PackageMember;
 import org.yakindu.base.types.TypedElement;
+import org.yakindu.sct.model.sgraph.*;
 import org.yakindu.sct.model.sgraph.Choice;
 import org.yakindu.sct.model.sgraph.CompositeElement;
 import org.yakindu.sct.model.sgraph.Effect;
@@ -285,6 +286,12 @@ public class SGraphSwitch<T> extends Switch<T> {
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
+			case SGraphPackage.SCOPE_MEMBER: {
+				ScopeMember scopeMember = (ScopeMember)theEObject;
+				T result = caseScopeMember(scopeMember);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
 			default: return defaultCase(theEObject);
 		}
 	}
@@ -526,6 +533,21 @@ public class SGraphSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	public T caseImportDeclaration(ImportDeclaration object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Scope Member</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Scope Member</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseScopeMember(ScopeMember object) {
 		return null;
 	}
 

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/StextPackage.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/StextPackage.java
@@ -303,7 +303,7 @@ public interface StextPackage extends EPackage {
 	int STATECHART_SCOPE = 8;
 
 	/**
-	 * The feature id for the '<em><b>Declarations</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Declarations</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -330,7 +330,7 @@ public interface StextPackage extends EPackage {
 	int STATECHART_SCOPE__VARIABLES = SGraphPackage.SCOPE__VARIABLES;
 
 	/**
-	 * The feature id for the '<em><b>Reactions</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Reactions</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -367,7 +367,7 @@ public interface StextPackage extends EPackage {
 	int INTERFACE_SCOPE = 9;
 
 	/**
-	 * The feature id for the '<em><b>Declarations</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Declarations</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -394,7 +394,7 @@ public interface StextPackage extends EPackage {
 	int INTERFACE_SCOPE__VARIABLES = STATECHART_SCOPE__VARIABLES;
 
 	/**
-	 * The feature id for the '<em><b>Reactions</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Reactions</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -440,7 +440,7 @@ public interface StextPackage extends EPackage {
 	int INTERNAL_SCOPE = 10;
 
 	/**
-	 * The feature id for the '<em><b>Declarations</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Declarations</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -467,7 +467,7 @@ public interface StextPackage extends EPackage {
 	int INTERNAL_SCOPE__VARIABLES = STATECHART_SCOPE__VARIABLES;
 
 	/**
-	 * The feature id for the '<em><b>Reactions</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Reactions</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -504,7 +504,7 @@ public interface StextPackage extends EPackage {
 	int IMPORT_SCOPE = 11;
 
 	/**
-	 * The feature id for the '<em><b>Declarations</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Declarations</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -531,7 +531,7 @@ public interface StextPackage extends EPackage {
 	int IMPORT_SCOPE__VARIABLES = STATECHART_SCOPE__VARIABLES;
 
 	/**
-	 * The feature id for the '<em><b>Reactions</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Reactions</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -1277,7 +1277,7 @@ public interface StextPackage extends EPackage {
 	int SIMPLE_SCOPE = 28;
 
 	/**
-	 * The feature id for the '<em><b>Declarations</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Declarations</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -1304,7 +1304,7 @@ public interface StextPackage extends EPackage {
 	int SIMPLE_SCOPE__VARIABLES = SGraphPackage.SCOPE__VARIABLES;
 
 	/**
-	 * The feature id for the '<em><b>Reactions</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Reactions</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/StextPackage.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/StextPackage.java
@@ -339,6 +339,15 @@ public interface StextPackage extends EPackage {
 	int STATECHART_SCOPE__REACTIONS = SGraphPackage.SCOPE__REACTIONS;
 
 	/**
+	 * The feature id for the '<em><b>Members</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int STATECHART_SCOPE__MEMBERS = SGraphPackage.SCOPE__MEMBERS;
+
+	/**
 	 * The number of structural features of the '<em>Statechart Scope</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -392,6 +401,15 @@ public interface StextPackage extends EPackage {
 	 * @ordered
 	 */
 	int INTERFACE_SCOPE__REACTIONS = STATECHART_SCOPE__REACTIONS;
+
+	/**
+	 * The feature id for the '<em><b>Members</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERFACE_SCOPE__MEMBERS = STATECHART_SCOPE__MEMBERS;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -458,6 +476,15 @@ public interface StextPackage extends EPackage {
 	int INTERNAL_SCOPE__REACTIONS = STATECHART_SCOPE__REACTIONS;
 
 	/**
+	 * The feature id for the '<em><b>Members</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_SCOPE__MEMBERS = STATECHART_SCOPE__MEMBERS;
+
+	/**
 	 * The number of structural features of the '<em>Internal Scope</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -511,6 +538,15 @@ public interface StextPackage extends EPackage {
 	 * @ordered
 	 */
 	int IMPORT_SCOPE__REACTIONS = STATECHART_SCOPE__REACTIONS;
+
+	/**
+	 * The feature id for the '<em><b>Members</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int IMPORT_SCOPE__MEMBERS = STATECHART_SCOPE__MEMBERS;
 
 	/**
 	 * The feature id for the '<em><b>Imports</b></em>' attribute list.
@@ -1275,6 +1311,15 @@ public interface StextPackage extends EPackage {
 	 * @ordered
 	 */
 	int SIMPLE_SCOPE__REACTIONS = SGraphPackage.SCOPE__REACTIONS;
+
+	/**
+	 * The feature id for the '<em><b>Members</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SIMPLE_SCOPE__MEMBERS = SGraphPackage.SCOPE__MEMBERS;
 
 	/**
 	 * The number of structural features of the '<em>Simple Scope</em>' class.

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/StextPackageImpl.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/StextPackageImpl.java
@@ -374,6 +374,8 @@ public class StextPackageImpl extends EPackageImpl implements StextPackage {
 
 		// Initialize simple dependencies
 		ExpressionsPackage.eINSTANCE.eClass();
+		BasePackage.eINSTANCE.eClass();
+		TypesPackage.eINSTANCE.eClass();
 		SGraphPackage.eINSTANCE.eClass();
 
 		// Create package meta-data objects

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/SText.xtext
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/SText.xtext
@@ -40,19 +40,19 @@ TransitionSpecification:
 	reaction=TransitionReaction;
 
 StateScope returns sgraph::Scope:
-	{SimpleScope} (reactions+=(LocalReaction))*;
+	{SimpleScope} (members+=(LocalReaction))*;
 
 StatechartScope:
 	InterfaceScope | InternalScope | ImportScope;
 
 InterfaceScope:
-	{InterfaceScope} 'interface' (name=XID)? ':' (declarations+=InterfaceScopeDeclaration)*;
+	{InterfaceScope} 'interface' (name=XID)? ':' (members+=InterfaceScopeDeclaration)*;
 
 InterfaceScopeDeclaration returns types::Declaration:
 	EventDefinition | VariableDefinition | TypeAliasDefinition | OperationDefinition;
 
 InternalScope:
-	{InternalScope} 'internal' ':' ((declarations+=InternalScopeDeclaration) | (reactions +=LocalReaction))*
+	{InternalScope} 'internal' ':' (members+=(InternalScopeDeclaration | LocalReaction))*
 ;
 InternalScopeDeclaration returns types::Declaration:
 	EventDefinition | VariableDefinition | OperationDefinition | TypeAliasDefinition

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/STextRuntimeModule.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/STextRuntimeModule.java
@@ -15,6 +15,7 @@ import org.eclipse.xtext.Constants;
 import org.eclipse.xtext.linking.ILinker;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.parser.antlr.IReferableElementsUnloader;
+import org.eclipse.xtext.parsetree.reconstr.ITransientValueService;
 import org.eclipse.xtext.resource.IDefaultResourceDescriptionStrategy;
 import org.eclipse.xtext.validation.CompositeEValidator;
 import org.yakindu.base.types.inferrer.ITypeSystemInferrer;
@@ -26,6 +27,7 @@ import org.yakindu.sct.model.stext.naming.StextNameProvider;
 import org.yakindu.sct.model.stext.resource.SCTResourceDescriptionStrategy;
 import org.yakindu.sct.model.stext.resource.StextResource;
 import org.yakindu.sct.model.stext.scoping.STextGlobalScopeProvider;
+import org.yakindu.sct.model.stext.serialization.STextTransientValueService;
 import org.yakindu.sct.model.stext.terminals.STextValueConverterService;
 
 import com.google.inject.Binder;
@@ -92,6 +94,11 @@ public class STextRuntimeModule extends org.yakindu.sct.model.stext.AbstractSTex
 
 	public Class<? extends ITypeSystemInferrer> bindITypeSystemInferrer() {
 		return STextTypeInferrer.class;
+	}
+	
+	@Override
+	public Class<? extends ITransientValueService> bindITransientValueService() {
+		return STextTransientValueService.class;
 	}
 
 }

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/resource/StextResource.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/resource/StextResource.java
@@ -11,20 +11,10 @@
 
 package org.yakindu.sct.model.stext.resource;
 
-import java.util.Map;
-
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.xtext.EcoreUtil2;
-import org.eclipse.xtext.TerminalRule;
-import org.eclipse.xtext.nodemodel.ICompositeNode;
-import org.eclipse.xtext.nodemodel.ILeafNode;
-import org.eclipse.xtext.nodemodel.impl.HiddenLeafNode;
-import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.parser.IParseResult;
 import org.yakindu.base.types.Annotation;
-import org.yakindu.base.types.Declaration;
 import org.yakindu.sct.model.sgraph.Reaction;
 import org.yakindu.sct.model.sgraph.ReactionProperty;
 import org.yakindu.sct.model.sgraph.Scope;
@@ -33,13 +23,10 @@ import org.yakindu.sct.model.sgraph.Statechart;
 import org.yakindu.sct.model.sgraph.Transition;
 import org.yakindu.sct.model.sgraph.resource.AbstractSCTResource;
 import org.yakindu.sct.model.stext.stext.ArgumentedAnnotation;
-import org.yakindu.sct.model.stext.stext.InternalScope;
 import org.yakindu.sct.model.stext.stext.StateSpecification;
 import org.yakindu.sct.model.stext.stext.StatechartSpecification;
 import org.yakindu.sct.model.stext.stext.TransitionReaction;
 import org.yakindu.sct.model.stext.stext.TransitionSpecification;
-
-import com.google.common.collect.Maps;
 
 /**
  * 
@@ -48,9 +35,6 @@ import com.google.common.collect.Maps;
  */
 public class StextResource extends AbstractSCTResource {
 
-	private static final String SINGLELINE_COMMENT_TERMINAL = "SL";
-	private static final String MULTILINE_COMMENT_TERMINAL = "ML";
-	private static final String WHITESPACE_TERMINAL = "WS";
 	private static final String NEW_LINE = System.lineSeparator();
 
 	public StextResource() {
@@ -73,121 +57,10 @@ public class StextResource extends AbstractSCTResource {
 			builder.append(NEW_LINE);
 		}
 		for (Scope scope : statechart.getScopes()) {
-			builder.append(serializeScope(scope));
+			builder.append(serialize(scope));
 			builder.append(NEW_LINE);
 		}
 		statechart.setSpecification(builder.toString());
-	}
-
-	protected String serializeScope(Scope scope) {
-		StringBuilder builder = new StringBuilder();
-		if (scope instanceof InternalScope) {
-			builder.append(serializeInternalScope((InternalScope) scope));
-		} else {
-			builder.append(serialize(scope));
-		}
-		return builder.toString();
-	}
-
-	protected String serializeInternalScope(InternalScope internalScope) {
-		StringBuilder builder = new StringBuilder();
-		InternalScope copiedScope = copyAndStripInternalScope(internalScope);
-		builder.append(serialize(copiedScope));
-		Map<Integer, EObject> specificationElements = Maps.newTreeMap();
-		for (Declaration declaration : internalScope.getDeclarations()) {
-			int lineNumber = getNodeLineNumber(declaration);
-			specificationElements.put(lineNumber, declaration);
-		}
-		for (Reaction reaction : internalScope.getReactions()) {
-			int lineNumber = getNodeLineNumber(reaction);
-			specificationElements.put(lineNumber, reaction);
-		}
-
-		for (Integer lineNumber : specificationElements.keySet()) {
-			EObject node = specificationElements.get(lineNumber);
-			Iterable<ILeafNode> leafNodes = NodeModelUtils.findActualNodeFor(node).getLeafNodes();
-			for (ILeafNode iLeafNode : leafNodes) {
-				if (iLeafNode instanceof HiddenLeafNode) {
-					HiddenLeafNode hiddenLeafNode = (HiddenLeafNode) iLeafNode;
-					if (hiddenLeafNode.getGrammarElement() instanceof TerminalRule) {
-						TerminalRule terminalRule = (TerminalRule) hiddenLeafNode.getGrammarElement();
-						int startLine = hiddenLeafNode.getStartLine();
-						int endLine = hiddenLeafNode.getEndLine();
-
-						if (!terminalRule.getName().contains(SINGLELINE_COMMENT_TERMINAL)) {
-							if (terminalRule.getName().contains(MULTILINE_COMMENT_TERMINAL)) {
-								if (endLine - startLine == 0) { // Multiline comment in single line
-									builder.append(NEW_LINE); // add linebreak between contiguous comments
-								}
-								break;
-							}
-						} else {
-							if (nextNodesAreWhitespace(hiddenLeafNode)) {
-								builder.append(NEW_LINE); // add linebreak if there are contiguous whitespaces
-								break;
-							}
-							endLine--; // reduces new lines if single line comment is present
-						}
-						for (int i = startLine; i < endLine; i++)
-							builder.append(NEW_LINE);
-
-					} else
-						break; // break on first non-hidden leaf node
-				}
-			}
-			builder.append(serializeInteralScopeContents(node));
-		}
-		return builder.toString();
-	}
-
-	private boolean nextNodesAreWhitespace(HiddenLeafNode hiddenLeafNode) {
-		if (hiddenLeafNode.getNextSibling() != null && hiddenLeafNode.getNextSibling().getNextSibling() != null) {
-			EObject next = hiddenLeafNode.getNextSibling().getGrammarElement();
-			EObject secondNext = hiddenLeafNode.getNextSibling().getNextSibling().getGrammarElement();
-			if (next != null && next instanceof TerminalRule && secondNext != null
-					&& secondNext instanceof TerminalRule) {
-				TerminalRule nextRule = (TerminalRule) next;
-				TerminalRule secondNextRule = (TerminalRule) secondNext;
-				if (nextRule.getName().contains(WHITESPACE_TERMINAL)
-						&& secondNextRule.getName().contains(WHITESPACE_TERMINAL)) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	private String serializeInteralScopeContents(EObject node) {
-		StringBuilder builder = new StringBuilder();
-		if (node instanceof Reaction) {
-			builder.append(serializeReaction((Reaction) node).trim());
-		} else {
-			builder.append(serialize(node));
-		}
-		return builder.toString();
-	}
-
-	protected int getNodeLineNumber(EObject object) {
-		ICompositeNode node = NodeModelUtils.getNode(object);
-		int lineNumber = node.getStartLine();
-		return lineNumber;
-	}
-
-	/**
-	 * Copies and strips the given internal scope to only contain the comments and
-	 * the "internal" keyword for serializing.
-	 * 
-	 * @param internalScope
-	 *            the internal scope to be copied and stripped
-	 * @return a copied internal scope with stripped contents
-	 */
-	protected InternalScope copyAndStripInternalScope(InternalScope internalScope) {
-		InternalScope copiedScope = EcoreUtil2.copy(internalScope);
-		copiedScope.getReactions().clear();
-		copiedScope.getDeclarations().clear();
-		copiedScope.eAdapters().addAll(internalScope.eAdapters());
-		EcoreUtil2.resolveAll(copiedScope);
-		return copiedScope;
 	}
 
 	protected void serializeState(State state) {

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/resource/StextResource.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/resource/StextResource.java
@@ -11,9 +11,17 @@
 
 package org.yakindu.sct.model.stext.resource;
 
+import java.util.Map;
+
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.EcoreUtil2;
+import org.eclipse.xtext.TerminalRule;
+import org.eclipse.xtext.nodemodel.ICompositeNode;
+import org.eclipse.xtext.nodemodel.ILeafNode;
+import org.eclipse.xtext.nodemodel.impl.HiddenLeafNode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.parser.IParseResult;
 import org.yakindu.base.types.Annotation;
 import org.yakindu.base.types.Declaration;
@@ -31,12 +39,19 @@ import org.yakindu.sct.model.stext.stext.StatechartSpecification;
 import org.yakindu.sct.model.stext.stext.TransitionReaction;
 import org.yakindu.sct.model.stext.stext.TransitionSpecification;
 
+import com.google.common.collect.Maps;
+
 /**
  * 
  * @author andreas muelder - Initial contribution and API
  * 
  */
 public class StextResource extends AbstractSCTResource {
+
+	private static final String SINGLELINE_COMMENT_TERMINAL = "SL";
+	private static final String MULTILINE_COMMENT_TERMINAL = "ML";
+	private static final String WHITESPACE_TERMINAL = "WS";
+	private static final String NEW_LINE = System.lineSeparator();
 
 	public StextResource() {
 		this(null);
@@ -51,15 +66,15 @@ public class StextResource extends AbstractSCTResource {
 		StringBuilder builder = new StringBuilder();
 		if (statechart.getNamespace() != null) {
 			builder.append("namespace " + statechart.getNamespace());
-			builder.append("\n");
+			builder.append(NEW_LINE);
 		}
 		for (Annotation annotation : statechart.getAnnotations()) {
 			builder.append(serialize(annotation));
-			builder.append("\n");
+			builder.append(NEW_LINE);
 		}
 		for (Scope scope : statechart.getScopes()) {
 			builder.append(serializeScope(scope));
-			builder.append("\n");
+			builder.append(NEW_LINE);
 		}
 		statechart.setSpecification(builder.toString());
 	}
@@ -78,18 +93,84 @@ public class StextResource extends AbstractSCTResource {
 		StringBuilder builder = new StringBuilder();
 		InternalScope copiedScope = copyAndStripInternalScope(internalScope);
 		builder.append(serialize(copiedScope));
-		builder.append("\n");
-
-		for (Declaration declaration : internalScope.getDeclarations()) {	
-			builder.append(serialize(declaration));
-			builder.append("\n");
+		Map<Integer, EObject> specificationElements = Maps.newTreeMap();
+		for (Declaration declaration : internalScope.getDeclarations()) {
+			int lineNumber = getNodeLineNumber(declaration);
+			specificationElements.put(lineNumber, declaration);
 		}
-		builder.append("\n");
 		for (Reaction reaction : internalScope.getReactions()) {
-			builder.append(serializeReaction(reaction));
-			builder.append("\n");
+			int lineNumber = getNodeLineNumber(reaction);
+			specificationElements.put(lineNumber, reaction);
+		}
+
+		for (Integer lineNumber : specificationElements.keySet()) {
+			EObject node = specificationElements.get(lineNumber);
+			Iterable<ILeafNode> leafNodes = NodeModelUtils.findActualNodeFor(node).getLeafNodes();
+			for (ILeafNode iLeafNode : leafNodes) {
+				if (iLeafNode instanceof HiddenLeafNode) {
+					HiddenLeafNode hiddenLeafNode = (HiddenLeafNode) iLeafNode;
+					if (hiddenLeafNode.getGrammarElement() instanceof TerminalRule) {
+						TerminalRule terminalRule = (TerminalRule) hiddenLeafNode.getGrammarElement();
+						int startLine = hiddenLeafNode.getStartLine();
+						int endLine = hiddenLeafNode.getEndLine();
+
+						if (!terminalRule.getName().contains(SINGLELINE_COMMENT_TERMINAL)) {
+							if (terminalRule.getName().contains(MULTILINE_COMMENT_TERMINAL)) {
+								if (endLine - startLine == 0) { // Multiline comment in single line
+									builder.append(NEW_LINE); // add linebreak between contiguous comments
+								}
+								break;
+							}
+						} else {
+							if (nextNodesAreWhitespace(hiddenLeafNode)) {
+								builder.append(NEW_LINE); // add linebreak if there are contiguous whitespaces
+								break;
+							}
+							endLine--; // reduces new lines if single line comment is present
+						}
+						for (int i = startLine; i < endLine; i++)
+							builder.append(NEW_LINE);
+
+					} else
+						break; // break on first non-hidden leaf node
+				}
+			}
+			builder.append(serializeInteralScopeContents(node));
 		}
 		return builder.toString();
+	}
+
+	private boolean nextNodesAreWhitespace(HiddenLeafNode hiddenLeafNode) {
+		if (hiddenLeafNode.getNextSibling() != null && hiddenLeafNode.getNextSibling().getNextSibling() != null) {
+			EObject next = hiddenLeafNode.getNextSibling().getGrammarElement();
+			EObject secondNext = hiddenLeafNode.getNextSibling().getNextSibling().getGrammarElement();
+			if (next != null && next instanceof TerminalRule && secondNext != null
+					&& secondNext instanceof TerminalRule) {
+				TerminalRule nextRule = (TerminalRule) next;
+				TerminalRule secondNextRule = (TerminalRule) secondNext;
+				if (nextRule.getName().contains(WHITESPACE_TERMINAL)
+						&& secondNextRule.getName().contains(WHITESPACE_TERMINAL)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private String serializeInteralScopeContents(EObject node) {
+		StringBuilder builder = new StringBuilder();
+		if (node instanceof Reaction) {
+			builder.append(serializeReaction((Reaction) node).trim());
+		} else {
+			builder.append(serialize(node));
+		}
+		return builder.toString();
+	}
+
+	protected int getNodeLineNumber(EObject object) {
+		ICompositeNode node = NodeModelUtils.getNode(object);
+		int lineNumber = node.getStartLine();
+		return lineNumber;
 	}
 
 	/**
@@ -117,7 +198,7 @@ public class StextResource extends AbstractSCTResource {
 		StringBuilder builder = new StringBuilder();
 		for (Reaction reaction : reactions) {
 			if (builder.length() > 0)
-				builder.append("\n");
+				builder.append(NEW_LINE);
 			builder.append(serializeReaction(reaction));
 		}
 		state.setSpecification(builder.toString());

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/serialization/STextTransientValueService.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/serialization/STextTransientValueService.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2017 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ * 
+ */
+package org.yakindu.sct.model.stext.serialization;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.xtext.parsetree.reconstr.impl.DefaultTransientValueService;
+import org.yakindu.sct.model.stext.stext.LocalReaction;
+
+/**
+ * @author robert rudi - Initial contribution and API
+ * 
+ */
+public class STextTransientValueService extends DefaultTransientValueService {
+
+	@Override
+	public boolean isTransient(EObject owner, EStructuralFeature feature, int index) {
+		return (owner instanceof LocalReaction) ? false : super.isTransient(owner, feature, index);
+	}
+
+}

--- a/test-plugins/org.yakindu.sct.model.stext.resource.test/src/org/yakindu/sct/model/stext/resource/test/SCTResourceTest.java
+++ b/test-plugins/org.yakindu.sct.model.stext.resource.test/src/org/yakindu/sct/model/stext/resource/test/SCTResourceTest.java
@@ -164,7 +164,7 @@ public class SCTResourceTest {
 		Scope internalScope = (InternalScope) statechart.getScopes().get(0);
 		Event event = internalScope.getEvents().get(0);
 		event.setName("Event2");
-		assertEquals("internal:event Event2", statechart.getSpecification().trim());
+		assertEquals("internal: event Event2", statechart.getSpecification().trim());
 		assertEquals("" + res.getSyntaxDiagnostics(), 0, res.getSyntaxDiagnostics().size());
 	}
 

--- a/test-plugins/org.yakindu.sct.model.stext.resource.test/src/org/yakindu/sct/model/stext/resource/test/SCTResourceTest.java
+++ b/test-plugins/org.yakindu.sct.model.stext.resource.test/src/org/yakindu/sct/model/stext/resource/test/SCTResourceTest.java
@@ -164,7 +164,7 @@ public class SCTResourceTest {
 		Scope internalScope = (InternalScope) statechart.getScopes().get(0);
 		Event event = internalScope.getEvents().get(0);
 		event.setName("Event2");
-		assertEquals("internal:\nevent Event2\n", statechart.getSpecification());
+		assertEquals("internal:event Event2", statechart.getSpecification().trim());
 		assertEquals("" + res.getSyntaxDiagnostics(), 0, res.getSyntaxDiagnostics().size());
 	}
 

--- a/test-plugins/org.yakindu.sct.model.stext.resource.test/src/org/yakindu/sct/model/stext/resource/test/SCTResourceTest.java
+++ b/test-plugins/org.yakindu.sct.model.stext.resource.test/src/org/yakindu/sct/model/stext/resource/test/SCTResourceTest.java
@@ -164,7 +164,7 @@ public class SCTResourceTest {
 		Scope internalScope = (InternalScope) statechart.getScopes().get(0);
 		Event event = internalScope.getEvents().get(0);
 		event.setName("Event2");
-		assertEquals("internal: event Event2\n", statechart.getSpecification());
+		assertEquals("internal:\nevent Event2\n", statechart.getSpecification());
 		assertEquals("" + res.getSyntaxDiagnostics(), 0, res.getSyntaxDiagnostics().size());
 	}
 

--- a/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/SCTUnitClassifierTest.java
+++ b/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/SCTUnitClassifierTest.java
@@ -55,8 +55,9 @@ public class SCTUnitClassifierTest {
 			StextPackage.Literals.BUILTIN_EVENT_SPEC, StextPackage.Literals.EVENT_SPEC,
 			StextPackage.Literals.IMPORT_SCOPE, StextPackage.Literals.STATECHART_SCOPE,
 			SGraphPackage.Literals.IMPORT_DECLARATION, SGraphPackage.Literals.SCOPE,
-			StextPackage.Literals.TRANSITION_REACTION, SGraphPackage.Literals.REACTION_PROPERTY,
-			StextPackage.Literals.ARGUMENTED_ANNOTATION, ExpressionsPackage.Literals.BINARY_LITERAL);
+			SGraphPackage.Literals.SCOPE_MEMBER, StextPackage.Literals.TRANSITION_REACTION,
+			SGraphPackage.Literals.REACTION_PROPERTY, StextPackage.Literals.ARGUMENTED_ANNOTATION,
+			ExpressionsPackage.Literals.BINARY_LITERAL);
 
 	@Test
 	public void checkEClassesCoveredByTestModels() throws Exception {


### PR DESCRIPTION
…an invalid model.

The origin of the element will now be in the context of the refactoring. The rename refactoring does remember the order of the internal scope specification elements while serializing.