### PR TITLE
Fixes #1239 Prefixed interface names for non-unique declarations …

### DIFF
--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/EventNaming.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/EventNaming.xtend
@@ -26,7 +26,7 @@ class EventNaming {
 	@Inject extension INamingService
 	
 	def eventEnumMemberName(Event it) {
-		'''«scope.functionPrefix»_«name.asIdentifier»'''
+		'''«scope.functionPrefix(it)»_«name.asIdentifier»'''
 	}
 	
 	def eventEnumName(ExecutionFlow it) {


### PR DESCRIPTION
… when using IdentifierSettings feature in sgen.

After adding the following snippet into the .sgen file for a C-Generator Project, the C-Generator has been generating functions with the same signature, instead of adding prefixes of the named interfaces.
```
feature IdentifierSettings {
   moduleName = "DspControl"
   statemachinePrefix = "DspCtrl"
   maxIdentifierLength = 64
   separator = "_"
}
```
With this fix, all functions that will be generated by the C-Generator will be prefixed with the name of corresponding interface (if there is any) for all non-unique declarations that are defined in the scope. 
Previously generated code won't be affected.