### PR TITLE
Fixes #1771 prefixing event enum value for the invalid event …

### DIFF
--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/Types.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/Types.xtend
@@ -63,6 +63,7 @@ class Types implements IContentTemplate {
 		
 		#define bool_true true
 		#define bool_false false
+		#define sc_invalid_event_value 0
 		
 		#endif /* «typesModule.define»_H_ */
 	'''

--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/EventDrivenStatemachineSource.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/EventDrivenStatemachineSource.xtend
@@ -123,7 +123,7 @@ class EventDrivenStatemachineSource extends StatemachineSource {
 				«functionPrefix»dispatch_event(«scHandle», &currentEvent);
 				«runCycleForLoop»
 				«clearInEventsFctID»(«scHandle»);
-			} while((currentEvent = «eventQueuePopFunction»(&(«scHandle»->internal_event_queue))).name != invalid_event);
+			} while((currentEvent = «eventQueuePopFunction»(&(«scHandle»->internal_event_queue))).name != «invalidEventEnumName»);
 			
 		}
 	'''

--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/EventNaming.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/EventNaming.xtend
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  *     committers of YAKINDU - initial API and implementation
  */
@@ -24,51 +24,55 @@ class EventNaming {
 	@Inject extension Naming
 	@Inject extension Navigation
 	@Inject extension INamingService
-	
+
 	def eventEnumMemberName(Event it) {
 		'''«scope.functionPrefix(it)»_«name.asIdentifier»'''
 	}
-	
+
+	def invalidEventEnumName(ExecutionFlow it) {
+		'''«module»_invalid_event'''.toString.toLowerCase
+	}
+
 	def eventEnumName(ExecutionFlow it) {
 		'''«module»_event_name'''.toString.toLowerCase
 	}
-	
+
 	def eventValueUnionName(ExecutionFlow it) {
 		'''«module»_event_value'''.toString.toLowerCase
 	}
-	
+
 	def eventStructTypeName(ExecutionFlow it) {
 		'''«name»_event'''.toString.toLowerCase
 	}
-	
+
 	def eventQueueTypeName(ExecutionFlow it) {
 		'''«name»_eventqueue'''.toString.toLowerCase
 	}
-	
+
 	def eventInitFunction(ExecutionFlow it) {
 		'''«eventStructTypeName»_init'''
 	}
-	
+
 	def valueEventInitFunction(ExecutionFlow it) {
 		'''«eventStructTypeName»_value_init'''
 	}
-	
+
 	def eventQueueInitFunction(ExecutionFlow it) {
 		'''«eventQueueTypeName»_init'''
 	}
-	
+
 	def eventQueueSizeFunction(ExecutionFlow it) {
 		'''«eventQueueTypeName»_size'''
 	}
-	
+
 	def eventQueuePopFunction(ExecutionFlow it) {
 		'''«eventQueueTypeName»_pop'''
 	}
-	
+
 	def eventQueuePushFunction(ExecutionFlow it) {
 		'''«eventQueueTypeName»_push'''
 	}
-	
+
 	def bufferSize(ExecutionFlow it) {
 		'''«name»_eventqueue_buffersize'''.toString.toUpperCase
 	}

--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/StatechartEventsHeader.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/StatechartEventsHeader.xtend
@@ -57,7 +57,7 @@ class StatechartEventsHeader {
 		 * Enum of event names in the statechart.
 		 */
 		typedef enum  {
-			invalid_event,
+			«invalidEventEnumName(it)» = sc_invalid_event_value,
 			«FOR e : getAllEvents SEPARATOR ","»
 				«eventEnumMemberName(e)»
 			«ENDFOR»

--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/StatechartEventsSource.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/eventdriven/StatechartEventsSource.xtend
@@ -76,7 +76,7 @@ class StatechartEventsSource {
 		{
 			«eventStructTypeName» event;
 			if(«eventQueueSizeFunction»(eq) <= 0) {
-				«eventInitFunction»(&event, invalid_event);
+				«eventInitFunction»(&event, «invalidEventEnumName(it)»);
 			}
 			else {
 				event = eq->events[eq->pop_index];


### PR DESCRIPTION
…by default with the name of the module. Added  #define sc_invalid_event_value 0 for sc types.