### PR TITLE
Allow packages to be PackageMembers

### DIFF
--- a/plugins/org.yakindu.base.types/model/types.ecore
+++ b/plugins/org.yakindu.base.types/model/types.ecore
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="types" nsURI="http://www.yakindu.org/base/types/2.0.0" nsPrefix="types">
-  <eClassifiers xsi:type="ecore:EClass" name="Package" eSuperTypes="base.ecore#//NamedElement">
+  <eClassifiers xsi:type="ecore:EClass" name="Package" eSuperTypes="#//PackageMember">
     <eStructuralFeatures xsi:type="ecore:EReference" name="member" upperBound="-1"
         eType="#//PackageMember" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="domain" eType="#//Domain"

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/Package.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/Package.java
@@ -23,7 +23,7 @@ import org.yakindu.base.base.NamedElement;
  * @model
  * @generated
  */
-public interface Package extends NamedElement {
+public interface Package extends PackageMember {
 	/**
 	 * Returns the value of the '<em><b>Member</b></em>' containment reference list.
 	 * The list contents are of type {@link org.yakindu.base.types.PackageMember}.

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/TypesPackage.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/TypesPackage.java
@@ -72,51 +72,6 @@ public interface TypesPackage extends EPackage {
 	int PACKAGE = 0;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int PACKAGE__NAME = BasePackage.NAMED_ELEMENT__NAME;
-
-	/**
-	 * The feature id for the '<em><b>Member</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int PACKAGE__MEMBER = BasePackage.NAMED_ELEMENT_FEATURE_COUNT + 0;
-
-	/**
-	 * The feature id for the '<em><b>Domain</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int PACKAGE__DOMAIN = BasePackage.NAMED_ELEMENT_FEATURE_COUNT + 1;
-
-	/**
-	 * The feature id for the '<em><b>Import</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int PACKAGE__IMPORT = BasePackage.NAMED_ELEMENT_FEATURE_COUNT + 2;
-
-	/**
-	 * The number of structural features of the '<em>Package</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int PACKAGE_FEATURE_COUNT = BasePackage.NAMED_ELEMENT_FEATURE_COUNT + 3;
-
-	/**
 	 * The meta object id for the '{@link org.yakindu.base.types.impl.PackageMemberImpl <em>Package Member</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -161,6 +116,69 @@ public interface TypesPackage extends EPackage {
 	 * @ordered
 	 */
 	int PACKAGE_MEMBER_FEATURE_COUNT = BasePackage.NAMED_ELEMENT_FEATURE_COUNT + 2;
+
+	/**
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PACKAGE__NAME = PACKAGE_MEMBER__NAME;
+
+	/**
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PACKAGE__ID = PACKAGE_MEMBER__ID;
+
+	/**
+	 * The feature id for the '<em><b>Annotations</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PACKAGE__ANNOTATIONS = PACKAGE_MEMBER__ANNOTATIONS;
+
+	/**
+	 * The feature id for the '<em><b>Member</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PACKAGE__MEMBER = PACKAGE_MEMBER_FEATURE_COUNT + 0;
+
+	/**
+	 * The feature id for the '<em><b>Domain</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PACKAGE__DOMAIN = PACKAGE_MEMBER_FEATURE_COUNT + 1;
+
+	/**
+	 * The feature id for the '<em><b>Import</b></em>' reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PACKAGE__IMPORT = PACKAGE_MEMBER_FEATURE_COUNT + 2;
+
+	/**
+	 * The number of structural features of the '<em>Package</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PACKAGE_FEATURE_COUNT = PACKAGE_MEMBER_FEATURE_COUNT + 3;
 
 	/**
 	 * The meta object id for the '{@link org.yakindu.base.types.impl.TypeImpl <em>Type</em>}' class.

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/impl/PackageImpl.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/impl/PackageImpl.java
@@ -33,7 +33,7 @@ import org.yakindu.base.types.TypesPackage;
  *
  * @generated
  */
-public class PackageImpl extends NamedElementImpl implements org.yakindu.base.types.Package {
+public class PackageImpl extends PackageMemberImpl implements org.yakindu.base.types.Package {
 	/**
 	 * The cached value of the '{@link #getMember() <em>Member</em>}' containment reference list.
 	 * <!-- begin-user-doc -->

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/impl/TypesPackageImpl.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/impl/TypesPackageImpl.java
@@ -970,7 +970,7 @@ public class TypesPackageImpl extends EPackageImpl implements TypesPackage {
 		// Set bounds for type parameters
 
 		// Add supertypes to classes
-		packageEClass.getESuperTypes().add(theBasePackage.getNamedElement());
+		packageEClass.getESuperTypes().add(this.getPackageMember());
 		typeEClass.getESuperTypes().add(this.getPackageMember());
 		declarationEClass.getESuperTypes().add(this.getTypedElement());
 		declarationEClass.getESuperTypes().add(theBasePackage.getNamedElement());

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/util/TypesSwitch.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/util/TypesSwitch.java
@@ -91,7 +91,9 @@ public class TypesSwitch<T> extends Switch<T> {
 			case TypesPackage.PACKAGE: {
 				org.yakindu.base.types.Package package_ = (org.yakindu.base.types.Package)theEObject;
 				T result = casePackage(package_);
+				if (result == null) result = casePackageMember(package_);
 				if (result == null) result = caseNamedElement(package_);
+				if (result == null) result = caseAnnotatableElement(package_);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}


### PR DESCRIPTION
This allows packages to contain other packages which we need to represent nested types in Cpp classes.