### PR TITLE
Fixes #1800. For subdiagrams the definition section is only visible i…

### DIFF
--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editor/StatechartDiagramEditor.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editor/StatechartDiagramEditor.java
@@ -658,18 +658,8 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 	}
 
 	protected String getStatechartName() {
-		String statechartName = "";
-		EObject container = getContextObject();
-		if (container != null) {
-			while (container.eContainer() != null) {
-				container = container.eContainer();
-			}
-			if (container instanceof Statechart) {
-				Statechart statechart = (Statechart) container;
-				statechartName = statechart.getName();
-			}
-		}
-		return statechartName;
+		Statechart statechart = EcoreUtil2.getContainerOfType(getContextObject(), Statechart.class);
+		return statechart.getName();
 	}
 
 	protected void observeStatechartName(Text statechartNameLabel) {

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editor/StatechartDiagramEditor.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editor/StatechartDiagramEditor.java
@@ -67,14 +67,11 @@ import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.MouseTrackAdapter;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.events.PaintListener;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Transform;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -101,6 +98,7 @@ import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.yakindu.base.base.BasePackage;
 import org.yakindu.base.base.DomainElement;
+import org.yakindu.base.base.NamedElement;
 import org.yakindu.base.xtext.utils.gmf.resource.DirtyStateListener;
 import org.yakindu.base.xtext.utils.jface.fieldassist.CompletionProposalAdapter;
 import org.yakindu.base.xtext.utils.jface.viewers.FilteringMenuManager;
@@ -167,7 +165,7 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 	private ImageLabelPaintListener imageLabelPaintListener;
 
 	private StyledText xtextControl;
-	private Button switchControl;
+	private Label switchControl;
 
 	public StatechartDiagramEditor() {
 		super(true);
@@ -429,7 +427,7 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 	@Override
 	public void dispose() {
 		saveState(getMemento());
-		
+
 		removepropertyChangeListener();
 		if (validationListener != null) {
 			validationListener.dispose();
@@ -453,7 +451,7 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 
 	protected void disposeDefinitionSectionControls() {
 		if (switchListener != null && switchControl != null && !switchControl.isDisposed())
-			switchControl.removeSelectionListener(switchListener);
+			switchControl.removeMouseListener(switchListener);
 
 		if (resizeListener != null && getSash() != null && !getSash().isDisposed())
 			getSash().removeControlListener(resizeListener);
@@ -500,7 +498,7 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 		Composite definitionSection = new Composite(parent, SWT.BORDER);
 		GridLayoutFactory.fillDefaults().numColumns(2).spacing(0, 0).applyTo(definitionSection);
 
-		switchControl = createExpandControl(definitionSection);
+		switchControl = createSwitchControl(definitionSection);
 		createDefinitionSectionLabels(definitionSection);
 		xtextControl = createXtextControl(definitionSection);
 
@@ -508,7 +506,7 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 		resizeListener = new ResizeListener(parent, definitionSection);
 
 		parent.addControlListener(resizeListener);
-		switchControl.addSelectionListener(switchListener);
+		switchControl.addMouseListener(switchListener);
 		xtextControl.addControlListener(resizeListener);
 	}
 
@@ -529,11 +527,14 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 		reloadFromPreferences();
 	}
 
+	/**
+	 * Checks if the pinning feature is activated. In case the definition section is
+	 * expanded, but the pinning feature was deactivated, the notation model will be
+	 * changed, so the inline statechart diagram style will be visible.
+	 */
 	protected void reloadFromPreferences() {
-		boolean pinningActivated = DiagramActivator.getDefault().getPreferenceStore()
-				.getBoolean(StatechartPreferenceConstants.PREF_DEFINITION_SECTION);
+		boolean pinningActivated = isPinningActivated();
 		if (!isDefinitionSectionInlined() && !pinningActivated) {
-			// set the new value for the boolean value style
 			TransactionalEditingDomain domain = TransactionUtil.getEditingDomain(getDiagram());
 			BooleanValueStyle inlineStyle = DiagramPartitioningUtil.getInlineDefinitionSectionStyle(getDiagram());
 
@@ -639,7 +640,10 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 		Text statechartNameLabel = new Text(labelComposite, SWT.SINGLE | SWT.NORMAL);
 		GridDataFactory.fillDefaults().indent(5, 1).grab(true, false).align(SWT.FILL, SWT.CENTER)
 				.applyTo(statechartNameLabel);
-		statechartNameLabel.setText(this.getTitle());
+
+		statechartNameLabel.setText(getStatechartName());
+		statechartNameLabel.setEditable(getContextObject() instanceof Statechart);
+		statechartNameLabel.setBackground(ColorConstants.white);
 		statechartNameLabel.addModifyListener(new ModifyListener() {
 
 			@Override
@@ -653,13 +657,31 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 		observeStatechartName(statechartNameLabel);
 	}
 
+	protected String getStatechartName() {
+		String statechartName = "";
+		EObject container = getContextObject();
+		if (container != null) {
+			while (container.eContainer() != null) {
+				container = container.eContainer();
+			}
+			if (container instanceof Statechart) {
+				Statechart statechart = (Statechart) container;
+				statechartName = statechart.getName();
+			}
+		}
+		return statechartName;
+	}
+
 	protected void observeStatechartName(Text statechartNameLabel) {
-		ValidatingEMFDatabindingContext context = new ValidatingEMFDatabindingContext(this, this.getSite().getShell());
-		IEMFValueProperty property = EMFEditProperties.value(TransactionUtil.getEditingDomain(getContextObject()),
-				BasePackage.Literals.NAMED_ELEMENT__NAME);
-		ISWTObservableValue observe = WidgetProperties.text(new int[]{SWT.FocusOut, SWT.DefaultSelection})
-				.observe(statechartNameLabel);
-		context.bindValue(observe, property.observe(this.getContextObject()));
+		if (getContextObject() instanceof Statechart) {
+			ValidatingEMFDatabindingContext context = new ValidatingEMFDatabindingContext(this,
+					this.getSite().getShell());
+			IEMFValueProperty property = EMFEditProperties.value(TransactionUtil.getEditingDomain(getContextObject()),
+					BasePackage.Literals.NAMED_ELEMENT__NAME);
+			ISWTObservableValue observe = WidgetProperties.text(new int[]{SWT.FocusOut, SWT.DefaultSelection})
+					.observe(statechartNameLabel);
+			context.bindValue(observe, property.observe(this.getContextObject()));
+		}
 	}
 
 	protected void createSeparator(Composite definitionSection) {
@@ -675,6 +697,7 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 			public void mouseUp(MouseEvent e) {
 				if (!isDefinitionSectionExpanded)
 					switchListener.handleSelection();
+				rotatedLabel.setCursor(new Cursor(Display.getDefault(), SWT.CURSOR_ARROW));
 			}
 		});
 		rotatedLabel.addMouseTrackListener(new MouseTrackAdapter() {
@@ -689,15 +712,15 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 				.hint(MIN_CONTROL_SIZE[0], definitionSection.getBounds().height).applyTo(rotatedLabel);
 	}
 
-	protected Button createExpandControl(Composite definitionSection) {
-		Button expandButton = new Button(definitionSection, SWT.PUSH | SWT.BORDER_SOLID);
-		expandButton.setToolTipText(COLLAPSE_TOOLTIP);
-		expandButton.setImage(
+	protected Label createSwitchControl(Composite definitionSection) {
+		Label switchLabel = new Label(definitionSection, SWT.PUSH);
+		switchLabel.setToolTipText(COLLAPSE_TOOLTIP);
+		switchLabel.setImage(
 				isDefinitionSectionExpanded ? StatechartImages.COLLAPSE.image() : StatechartImages.EXPAND.image());
-		expandButton.setCursor(new Cursor(Display.getDefault(), SWT.CURSOR_HAND));
+		switchLabel.setCursor(new Cursor(Display.getDefault(), SWT.CURSOR_HAND));
 		GridDataFactory.fillDefaults().align(SWT.FILL, SWT.CENTER).indent(-1, 0)
-				.hint(MIN_CONTROL_SIZE[0], MIN_CONTROL_SIZE[1]).applyTo(expandButton);
-		return expandButton;
+				.hint(MIN_CONTROL_SIZE[0], MIN_CONTROL_SIZE[1]).applyTo(switchLabel);
+		return switchLabel;
 	}
 
 	@Override
@@ -717,7 +740,14 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 
 	protected void collapseDefinitionSection(Composite parent) {
 		int width = parent.getBounds().width;
-		((SashForm) parent).setWeights(new int[]{switchControl.getBounds().width + BORDERWIDTH, width});
+		int[] sashWidths;
+		if (width - switchControl.getBounds().width < 0 || width < switchControl.getBounds().width) {
+			sashWidths = DEFAULT_WEIGHTS;
+		} else {
+			sashWidths = new int[]{switchControl.getBounds().width + BORDERWIDTH,
+					width - switchControl.getBounds().width};
+		}
+		((SashForm) parent).setWeights(sashWidths);
 		updateSwitchControl(EXPAND_TOOLTIP, EXPAND_IMAGE);
 	}
 
@@ -842,17 +872,12 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 	 * @author robert rudi - Initial contribution and API
 	 * 
 	 */
-	protected class SwitchListener extends SelectionAdapter {
+	protected class SwitchListener extends MouseAdapter {
 
 		protected final Composite parent;
 
 		protected SwitchListener(Composite parent) {
 			this.parent = parent;
-		}
-
-		@Override
-		public void widgetSelected(SelectionEvent e) {
-			handleSelection();
 		}
 
 		protected void handleSelection() {
@@ -872,6 +897,11 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 				}
 			}
 			parent.setRedraw(true);
+		}
+
+		@Override
+		public void mouseUp(MouseEvent e) {
+			handleSelection();
 		}
 	}
 
@@ -950,6 +980,18 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 	}
 
 	@Override
+	protected void rememberExpandState(IMemento memento) {
+		if (getContextObject() != null) {
+			if (getContextObject() instanceof NamedElement) {
+				NamedElement element = (NamedElement) getContextObject();
+				if (element != null)
+					memento.putBoolean(stripElementName(element.getName()) + IS_DEFINITION_SECTION_EXPANDED,
+							isDefinitionSectionExpanded);
+			}
+		}
+	}
+
+	@Override
 	public void restoreState(IMemento memento) {
 		if (getSash() != null && memento != null && memento.getInteger(FIRST_SASH_CONTROL_WEIGHT) != null
 				&& memento.getInteger(SECOND_SASH_CONTROL_WEIGHT) != null) {
@@ -961,9 +1003,19 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 		super.setMemento(memento);
 	}
 
+	protected boolean getExpandState(IMemento memento) {
+		Object expandState = null;
+		if (getContextObject() instanceof NamedElement) {
+			NamedElement element = (NamedElement) getContextObject();
+			if (element != null)
+				expandState = memento.getBoolean(stripElementName(element.getName()) + IS_DEFINITION_SECTION_EXPANDED);
+		}
+		return expandState != null ? ((Boolean) expandState).booleanValue() : false;
+	}
+
 	@Override
 	public void propertyChange(PropertyChangeEvent event) {
-		if(StatechartPreferenceConstants.PREF_DEFINITION_SECTION.equals(event.getProperty())) {
+		if (StatechartPreferenceConstants.PREF_DEFINITION_SECTION.equals(event.getProperty())) {
 			reloadFromPreferences();
 		}
 	}

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/partitioning/DiagramPartitioningEditor.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/partitioning/DiagramPartitioningEditor.java
@@ -63,9 +63,12 @@ import org.eclipse.ui.XMLMemento;
 import org.eclipse.ui.ide.FileStoreEditorInput;
 import org.eclipse.xtext.util.Arrays;
 import org.yakindu.base.base.NamedElement;
+import org.yakindu.sct.model.sgraph.State;
 import org.yakindu.sct.model.sgraph.Statechart;
 import org.yakindu.sct.model.sgraph.provider.SGraphItemProviderAdapterFactory;
+import org.yakindu.sct.ui.editor.DiagramActivator;
 import org.yakindu.sct.ui.editor.StatechartImages;
+import org.yakindu.sct.ui.editor.preferences.StatechartPreferenceConstants;
 
 /**
  * Editor that uses a {@link DiagramPartitioningDocumentProvider} and adds a
@@ -143,8 +146,17 @@ public abstract class DiagramPartitioningEditor extends DiagramDocumentEditor
 
 	public void toggleDefinitionSection() {
 		if (getContextObject() instanceof Statechart)
-			sash.setMaximizedControl(
-					!isDefinitionSectionInlined() ? null : sash.getChildren()[MAXIMIZED_CONTROL_INDEX]);
+			sash.setMaximizedControl(!isDefinitionSectionInlined() && isPinningActivated()
+					? null
+					: sash.getChildren()[MAXIMIZED_CONTROL_INDEX]);
+		if (getContextObject() instanceof State) {
+			sash.setMaximizedControl(isDefinitionSectionInlined() && isPinningActivated() ? null : sash.getChildren()[MAXIMIZED_CONTROL_INDEX]);
+		}
+	}
+
+	protected boolean isPinningActivated() {
+		return DiagramActivator.getDefault().getPreferenceStore()
+				.getBoolean(StatechartPreferenceConstants.PREF_DEFINITION_SECTION);
 	}
 
 	protected abstract EObject getContextObject();
@@ -162,25 +174,7 @@ public abstract class DiagramPartitioningEditor extends DiagramDocumentEditor
 		}
 	}
 
-	protected void rememberExpandState(IMemento memento) {
-		if (getContextObject() != null) {
-			if (getContextObject() instanceof NamedElement) {
-				NamedElement element = (NamedElement) getContextObject();
-				if (element != null)
-					memento.putBoolean(stripElementName(element.getName()) + IS_DEFINITION_SECTION_EXPANDED, true);
-			}
-		}
-	}
-
-	protected boolean getExpandState(IMemento memento) {
-		Object expandState = null;
-		if (getContextObject() instanceof NamedElement) {
-			NamedElement element = (NamedElement) getContextObject();
-			if (element != null)
-				expandState = memento.getBoolean(stripElementName(element.getName()) + IS_DEFINITION_SECTION_EXPANDED);
-		}
-		return expandState != null ? ((Boolean) expandState).booleanValue() : true;
-	}
+	protected abstract void rememberExpandState(IMemento memento);
 
 	protected String stripElementName(String name) {
 		if (name != null)


### PR DESCRIPTION
…f the pinning feature is activated.

Fixes #1799. The definition section now really remembers the last state of expansion (also for subdiagrams).
Fixes #1798. Replaced the SWT button control with SWT label to eliminate size issues of the switching control in the statechart definition section on different platforms.

For the pinned definition section the name at the top is now always the name of the root diagram.