### PR TITLE
Related to #1802, #1803. Assert the current context object to ensure …

### DIFF
--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editor/StatechartDiagramEditor.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editor/StatechartDiagramEditor.java
@@ -18,6 +18,7 @@ import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -274,7 +275,7 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 	}
 
 	protected Injector getEmbeddedStatechartSpecificationInjector() {
-		IDomain domain = DomainRegistry.getDomain(getDiagram().getElement());
+		IDomain domain = DomainRegistry.getDomain(getContextObject());
 		return domain.getInjector(IDomain.FEATURE_EDITOR, Statechart.class.getName());
 	}
 
@@ -715,7 +716,9 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor implement
 
 	@Override
 	public EObject getContextObject() {
-		return getDiagram().getElement();
+		EObject element = getDiagram().getElement();
+		Assert.isNotNull(element);
+		return element;
 	}
 
 	protected void initContextMenu(Control control) {


### PR DESCRIPTION
…the needed domain is instantiated correctly, so the statechart specification can be displayed correctly within the definition section.