### PR TITLE
Don't infer TypeParameters already specified by TypeArguments

### DIFF
--- a/plugins/org.yakindu.base.expressions/src/org/yakindu/base/expressions/inferrer/ExpressionsTypeInferrer.java
+++ b/plugins/org.yakindu.base.expressions/src/org/yakindu/base/expressions/inferrer/ExpressionsTypeInferrer.java
@@ -254,7 +254,21 @@ public class ExpressionsTypeInferrer extends AbstractTypeSystemInferrer implemen
 		// resolve type parameter from operation call
 		List<InferenceResult> argumentTypes = getArgumentTypes(getOperationArguments(e));
 		List<Parameter> parameters = op.getParameters();
-		typeParameterInferrer.inferTypeParametersFromOperationArguments(parameters, argumentTypes, typeParameterMapping,
+		
+		List<InferenceResult> argumentsToInfer = new ArrayList<>();
+		List<Parameter> parametersToInfer = new ArrayList<>();
+		
+		for(int i = 0; i < parameters.size(); i++) {
+			if(!typeParameterMapping.containsKey(parameters.get(i).getType())) {
+				parametersToInfer.add(parameters.get(i));
+				if(i < argumentTypes.size()) {
+					argumentsToInfer.add(argumentTypes.get(i));
+				}
+				
+			}
+		}
+		
+		typeParameterInferrer.inferTypeParametersFromOperationArguments(parametersToInfer, argumentsToInfer, typeParameterMapping,
 				acceptor);
 		validateParameters(typeParameterMapping, op, getOperationArguments(e), acceptor);
 		return inferReturnType(op, typeParameterMapping);

--- a/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/TypeInferrerTest.java
+++ b/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/TypeInferrerTest.java
@@ -926,6 +926,9 @@ public class TypeInferrerTest extends AbstractTypeInferrerTest {
 		expectNoErrors("b = t.op(true, 10)",
 				"internal var t:ComplexParameterizedType<boolean, integer> var b:boolean");
 
+		expectErrors("b = t.op(true, 10.5)",
+				"internal var t:ComplexParameterizedType<boolean, integer> var b:boolean", ITypeSystemInferrer.NOT_COMPATIBLE_CODE, 1);
+
 		assertTrue(isBooleanType(inferTypeResultForExpression("b = t.op(true, 10)",
 				"internal var t:ComplexParameterizedType<integer> var b:boolean").getType()));
 		


### PR DESCRIPTION
This fix stops SCT from inferring the type of parameters that are already specified via type arguments, e.g. a Point<T> already defined as Point<int32_t> shouldn't infer an operations' type to float when a float argument is given.