### PR TITLE
Removed preferences for the definition section pinning feature

### DIFF
--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/decoratorprovider/DefinitionSectionDecorationProvider.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/decoratorprovider/DefinitionSectionDecorationProvider.java
@@ -47,7 +47,6 @@ import org.yakindu.sct.ui.editor.StatechartImages;
 import org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor;
 import org.yakindu.sct.ui.editor.editparts.StatechartTextEditPart;
 import org.yakindu.sct.ui.editor.partitioning.DiagramPartitioningUtil;
-import org.yakindu.sct.ui.editor.preferences.StatechartPreferenceConstants;
 import org.yakindu.sct.ui.editor.utils.GMFNotationUtil;
 
 /**
@@ -87,15 +86,14 @@ public class DefinitionSectionDecorationProvider extends AbstractDecoratorProvid
 
 		@Override
 		protected boolean shouldDecorate(EObject element) {
-			if (preferenceStore.getBoolean(StatechartPreferenceConstants.PREF_DEFINITION_SECTION)) {
-				if (getDecoratorTarget().getAdapter(IPrimaryEditPart.class) instanceof StatechartTextEditPart) {
-					StatechartTextEditPart adapter = (StatechartTextEditPart) getDecoratorTarget()
-							.getAdapter(IPrimaryEditPart.class);
-					BooleanValueStyle style = GMFNotationUtil.getBooleanValueStyle(adapter.getNotationView(),
-							DiagramPartitioningUtil.INLINE_DEFINITION_SECTION_STYLE);
-					return style == null ? true : style.isBooleanValue();
-				}
+			if (getDecoratorTarget().getAdapter(IPrimaryEditPart.class) instanceof StatechartTextEditPart) {
+				StatechartTextEditPart adapter = (StatechartTextEditPart) getDecoratorTarget()
+						.getAdapter(IPrimaryEditPart.class);
+				BooleanValueStyle style = GMFNotationUtil.getBooleanValueStyle(adapter.getNotationView(),
+						DiagramPartitioningUtil.INLINE_DEFINITION_SECTION_STYLE);
+				return style == null ? true : style.isBooleanValue();
 			}
+
 			return false;
 		}
 

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editor/StatechartDiagramEditor.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editor/StatechartDiagramEditor.java
@@ -53,8 +53,6 @@ import org.eclipse.jface.databinding.swt.ISWTObservableValue;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
-import org.eclipse.jface.util.IPropertyChangeListener;
-import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.custom.StyledText;
@@ -120,7 +118,6 @@ import org.yakindu.sct.ui.editor.DiagramActivator;
 import org.yakindu.sct.ui.editor.StatechartImages;
 import org.yakindu.sct.ui.editor.partitioning.DiagramPartitioningEditor;
 import org.yakindu.sct.ui.editor.partitioning.DiagramPartitioningUtil;
-import org.yakindu.sct.ui.editor.preferences.StatechartPreferenceConstants;
 import org.yakindu.sct.ui.editor.propertysheets.ValidatingEMFDatabindingContext;
 import org.yakindu.sct.ui.editor.proposals.ContentProposalViewerKeyHandler;
 import org.yakindu.sct.ui.editor.providers.ISCTOutlineFactory;
@@ -138,11 +135,7 @@ import com.google.inject.Key;
  * @author robert rudi
  */
 @SuppressWarnings("restriction")
-public class StatechartDiagramEditor extends DiagramPartitioningEditor
-		implements
-			IGotoMarker,
-			IContextElementProvider,
-			IPropertyChangeListener {
+public class StatechartDiagramEditor extends DiagramPartitioningEditor implements IGotoMarker, IContextElementProvider {
 
 	public static final String ID = "org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor";
 
@@ -229,11 +222,6 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor
 		super.init(site, input);
 		checkXtextNature();
 		registerValidationListener();
-		registerPropertyChangeListener();
-	}
-
-	protected void registerPropertyChangeListener() {
-		DiagramActivator.getDefault().getPreferenceStore().addPropertyChangeListener(this);
 	}
 
 	protected void registerValidationListener() {
@@ -461,7 +449,6 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor
 	public void dispose() {
 		saveState(getMemento());
 
-		removepropertyChangeListener();
 		if (validationListener != null) {
 			validationListener.dispose();
 		}
@@ -478,9 +465,6 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor
 		super.dispose();
 	}
 
-	protected void removepropertyChangeListener() {
-		DiagramActivator.getDefault().getPreferenceStore().removePropertyChangeListener(this);
-	}
 
 	protected void disposeDefinitionSectionControls() {
 		if (switchListener != null && switchControl != null && !switchControl.isDisposed())
@@ -557,26 +541,6 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor
 		toggleDefinitionSection();
 		restoreSashWidths(getSash(), getMemento());
 		enableXtext(xtextControl);
-		reloadFromPreferences();
-	}
-
-	/**
-	 * Checks if the pinning feature is activated. In case the definition section is
-	 * expanded, but the pinning feature was deactivated, the notation model will be
-	 * changed, so the inline statechart diagram style will be visible.
-	 */
-	protected void reloadFromPreferences() {
-		boolean pinningActivated = isPinningActivated();
-		if (!isDefinitionSectionInlined() && !pinningActivated) {
-			TransactionalEditingDomain domain = TransactionUtil.getEditingDomain(getDiagram());
-			BooleanValueStyle inlineStyle = DiagramPartitioningUtil.getInlineDefinitionSectionStyle(getDiagram());
-
-			SetCommand command = setBooleanValueStyle(inlineStyle, domain);
-			domain.getCommandStack().execute(command);
-
-			toggleDefinitionSection();
-			refreshDiagramEditPartChildren();
-		}
 	}
 
 	protected void enableXtext(StyledText xtextControl) {
@@ -1046,14 +1010,7 @@ public class StatechartDiagramEditor extends DiagramPartitioningEditor
 			if (element != null)
 				expandState = memento.getBoolean(stripElementName(element.getName()) + IS_DEFINITION_SECTION_EXPANDED);
 		}
-		return expandState != null ? ((Boolean) expandState).booleanValue() : false;
-	}
-
-	@Override
-	public void propertyChange(PropertyChangeEvent event) {
-		if (StatechartPreferenceConstants.PREF_DEFINITION_SECTION.equals(event.getProperty())) {
-			reloadFromPreferences();
-		}
+		return expandState != null ? ((Boolean) expandState).booleanValue() : true;
 	}
 
 }

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editparts/StatechartTextEditPart.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editparts/StatechartTextEditPart.java
@@ -24,13 +24,9 @@ import org.eclipse.gmf.runtime.emf.type.core.requests.DestroyRequest;
 import org.eclipse.gmf.runtime.gef.ui.figures.NodeFigure;
 import org.eclipse.gmf.runtime.notation.BooleanValueStyle;
 import org.eclipse.gmf.runtime.notation.View;
-import org.eclipse.jface.util.IPropertyChangeListener;
-import org.eclipse.jface.util.PropertyChangeEvent;
-import org.yakindu.sct.ui.editor.DiagramActivator;
 import org.yakindu.sct.ui.editor.editor.figures.StatechartTextFigure;
 import org.yakindu.sct.ui.editor.partitioning.DiagramPartitioningUtil;
 import org.yakindu.sct.ui.editor.policies.PreferredSizeHandlerEditPolicy;
-import org.yakindu.sct.ui.editor.preferences.StatechartPreferenceConstants;
 import org.yakindu.sct.ui.editor.providers.SemanticHints;
 
 /**
@@ -38,7 +34,7 @@ import org.yakindu.sct.ui.editor.providers.SemanticHints;
  * @author andreas muelder - Initial contribution and API
  * 
  */
-public class StatechartTextEditPart extends ShapeNodeEditPart implements IPrimaryEditPart, IPropertyChangeListener {
+public class StatechartTextEditPart extends ShapeNodeEditPart implements IPrimaryEditPart {
 
 	public StatechartTextEditPart(View view) {
 		super(view);
@@ -56,13 +52,11 @@ public class StatechartTextEditPart extends ShapeNodeEditPart implements IPrimar
 	@Override
 	public void activate() {
 		super.activate();
-		DiagramActivator.getDefault().getPreferenceStore().addPropertyChangeListener(this);
 	}
 
 	@Override
 	public void deactivate() {
 		super.deactivate();
-		DiagramActivator.getDefault().getPreferenceStore().removePropertyChangeListener(this);
 	}
 
 	@Override
@@ -131,13 +125,5 @@ public class StatechartTextEditPart extends ShapeNodeEditPart implements IPrimar
 
 	private StatechartTextFigure getPrimaryShape() {
 		return (StatechartTextFigure) getFigure().getChildren().get(0);
-	}
-
-	@Override
-	public void propertyChange(PropertyChangeEvent event) {
-		if (StatechartPreferenceConstants.PREF_DEFINITION_SECTION.equals(event.getProperty())) {
-			refresh();
-		}
-
 	}
 }

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/partitioning/DiagramPartitioningEditor.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/partitioning/DiagramPartitioningEditor.java
@@ -148,13 +148,9 @@ public abstract class DiagramPartitioningEditor extends DiagramDocumentEditor
 	}
 
 	public void toggleDefinitionSection() {
-		if (getContextObject() instanceof Statechart)
-			sash.setMaximizedControl(!isDefinitionSectionInlined() 
-					? null
-					: sash.getChildren()[MAXIMIZED_CONTROL_INDEX]);
-		if (getContextObject() instanceof State) {
-			sash.setMaximizedControl(isDefinitionSectionInlined() ? null : sash.getChildren()[MAXIMIZED_CONTROL_INDEX]);
-		}
+		sash.setMaximizedControl(!isDefinitionSectionInlined() && getContextObject() instanceof Statechart
+				? null
+				: sash.getChildren()[MAXIMIZED_CONTROL_INDEX]);
 	}
 
 	protected abstract EObject getContextObject();
@@ -366,9 +362,9 @@ public abstract class DiagramPartitioningEditor extends DiagramDocumentEditor
 			}
 		}
 		@Override
-		 public boolean isAdapterForType(Object type) {
+		public boolean isAdapterForType(Object type) {
 			return type instanceof BreadcrumbSynchronizer;
-		 }
+		}
 	}
 
 	public static class FilteringDiagramContextMenuProvider extends DiagramContextMenuProvider {

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/partitioning/DiagramPartitioningEditor.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/partitioning/DiagramPartitioningEditor.java
@@ -70,9 +70,7 @@ import org.yakindu.base.base.NamedElement;
 import org.yakindu.sct.model.sgraph.State;
 import org.yakindu.sct.model.sgraph.Statechart;
 import org.yakindu.sct.model.sgraph.provider.SGraphItemProviderAdapterFactory;
-import org.yakindu.sct.ui.editor.DiagramActivator;
 import org.yakindu.sct.ui.editor.StatechartImages;
-import org.yakindu.sct.ui.editor.preferences.StatechartPreferenceConstants;
 
 /**
  * Editor that uses a {@link DiagramPartitioningDocumentProvider} and adds a
@@ -151,17 +149,12 @@ public abstract class DiagramPartitioningEditor extends DiagramDocumentEditor
 
 	public void toggleDefinitionSection() {
 		if (getContextObject() instanceof Statechart)
-			sash.setMaximizedControl(!isDefinitionSectionInlined() && isPinningActivated()
+			sash.setMaximizedControl(!isDefinitionSectionInlined() 
 					? null
 					: sash.getChildren()[MAXIMIZED_CONTROL_INDEX]);
 		if (getContextObject() instanceof State) {
-			sash.setMaximizedControl(isDefinitionSectionInlined() && isPinningActivated() ? null : sash.getChildren()[MAXIMIZED_CONTROL_INDEX]);
+			sash.setMaximizedControl(isDefinitionSectionInlined() ? null : sash.getChildren()[MAXIMIZED_CONTROL_INDEX]);
 		}
-	}
-
-	protected boolean isPinningActivated() {
-		return DiagramActivator.getDefault().getPreferenceStore()
-				.getBoolean(StatechartPreferenceConstants.PREF_DEFINITION_SECTION);
 	}
 
 	protected abstract EObject getContextObject();

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/preferences/PreferenceInitializer.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/preferences/PreferenceInitializer.java
@@ -68,8 +68,6 @@ public class PreferenceInitializer extends DiagramPreferenceInitializer implemen
 		getPreferenceStore().setDefault(StatechartPreferenceConstants.PREF_LIVE_VALIDATION, true);
 		// Syntax coloring
 		getPreferenceStore().setDefault(StatechartPreferenceConstants.PREF_SYNTAX_COLORING, false);
-		// Definition section pinning
-		getPreferenceStore().setDefault(StatechartPreferenceConstants.PREF_DEFINITION_SECTION, false);
 
 	}
 

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/preferences/StatechartAppearancePreferencePage.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/preferences/StatechartAppearancePreferencePage.java
@@ -51,7 +51,6 @@ public class StatechartAppearancePreferencePage extends FieldEditorPreferencePag
 		createLineStyleEditors(main);
 		createDefaultFontEditor(main);
 		createSyntaxColoringLabelEditor(main);
-		createPinnableStatechartDefinitionEditor(main);
 		createPriorityLabelEditor(main);
 		createLiveValidationEditor(main);
 	}
@@ -80,13 +79,6 @@ public class StatechartAppearancePreferencePage extends FieldEditorPreferencePag
 		Composite composite = createGroupComposite(main, "Syntax coloring");
 		BooleanFieldEditor editor = new BooleanFieldEditor(StatechartPreferenceConstants.PREF_SYNTAX_COLORING,
 				"Enable syntax coloring", composite);
-		addField(editor);
-	}
-	
-	protected void createPinnableStatechartDefinitionEditor(Composite main) {
-		Composite composite = createGroupComposite(main, "Definition section");
-		BooleanFieldEditor editor = new BooleanFieldEditor(StatechartPreferenceConstants.PREF_DEFINITION_SECTION,
-				"Enable pinning of statechart definition section", composite);
 		addField(editor);
 	}
 

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/preferences/StatechartPreferenceConstants.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/preferences/StatechartPreferenceConstants.java
@@ -26,5 +26,4 @@ public interface StatechartPreferenceConstants extends IPreferenceConstants {
 	String PREF_PRIORITY_LABELS = "Appearance.transition.priority";
 	String PREF_LIVE_VALIDATION = "Appearance.live.validation";
 	String PREF_SYNTAX_COLORING = "Appearance.diagram.syntaxcoloring";
-	String PREF_DEFINITION_SECTION = "Appearance.diagram.definitionsection";
 }


### PR DESCRIPTION
Removed preferences for enabling/disabling definition section pinning feature.
Pinning feature is now always enabled.

Also changed the behaviour for statechart diagrams with a pinned definition section. 
When the statechart diagram is opened for the first time  (with pinning activated in the NodeModel) the pinned definition section will always be shown in expanded state. 
If the statechart diagram was already opened within the workspace, the last active state of the definition section will be displayed.