### PR TITLE
Improve ErrorMarker navigation

### DIFF
--- a/plugins/org.yakindu.base.gmf.runtime/src/org/yakindu/base/gmf/runtime/editparts/TextAwareLabelEditPart.java
+++ b/plugins/org.yakindu.base.gmf.runtime/src/org/yakindu/base/gmf/runtime/editparts/TextAwareLabelEditPart.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * Contributors:
  * 	committers of YAKINDU - initial API and implementation
- * 
+ *
  */
 package org.yakindu.base.gmf.runtime.editparts;
 
@@ -43,16 +43,15 @@ import org.yakindu.base.xtext.utils.gmf.figures.SyntaxColoringLabel;
 /**
  * This is a common abstract base class for all Label which are
  * {@link ITextAwareEditPart}.
- * 
+ *
  * * This edit part is only to be used for labels inside a figure! for external
  * labels, use {@link TextAwareExternalLabelEditPart}
- * 
- * 
+ *
+ *
  * @author andreas muelder
- * 
+ *
  */
-public abstract class TextAwareLabelEditPart extends CompartmentEditPart
-		implements ITextAwareEditPart {
+public abstract class TextAwareLabelEditPart extends CompartmentEditPart implements ITextAwareEditPart {
 
 	private final DirectEditManager manager;
 
@@ -95,8 +94,7 @@ public abstract class TextAwareLabelEditPart extends CompartmentEditPart
 	@Override
 	protected void createDefaultEditPolicies() {
 		super.createDefaultEditPolicies();
-		installEditPolicy(EditPolicy.DIRECT_EDIT_ROLE,
-				new LabelDirectEditPolicy());
+		installEditPolicy(EditPolicy.DIRECT_EDIT_ROLE, new LabelDirectEditPolicy());
 		// TODO: Add a Feedback role
 	}
 
@@ -112,11 +110,12 @@ public abstract class TextAwareLabelEditPart extends CompartmentEditPart
 		getWrappingLabel().setForegroundColor(color);
 	}
 
+	@Override
 	public String getEditText() {
-		return getParser().getEditString(
-				new EObjectAdapter(resolveSemanticElement()), -1);
+		return getParser().getEditString(new EObjectAdapter(resolveSemanticElement()), -1);
 	}
 
+	@Override
 	public void setLabelText(String text) {
 		updateLabelText();
 	}
@@ -130,18 +129,29 @@ public abstract class TextAwareLabelEditPart extends CompartmentEditPart
 		return new SyntaxColoringLabel();
 	}
 
+	@Override
 	public ICellEditorValidator getEditTextValidator() {
 		return null;
 	}
 
+	@Override
 	public ParserOptions getParserOptions() {
 		return ParserOptions.NONE;
 	}
 
+	@Override
 	public IParser getParser() {
 		return new StringAttributeParser(feature, pluginId);
 	}
 
+	/**
+	 * @return the feature
+	 */
+	public EAttribute getFeature() {
+		return feature;
+	}
+
+	@Override
 	public IContentAssistProcessor getCompletionProcessor() {
 		return null;
 	}
@@ -150,8 +160,7 @@ public abstract class TextAwareLabelEditPart extends CompartmentEditPart
 	 */
 	@Override
 	public DragTracker getDragTracker(final Request request) {
-		if (request instanceof SelectionRequest
-				&& ((SelectionRequest) request).getLastButtonPressed() == 3)
+		if (request instanceof SelectionRequest && ((SelectionRequest) request).getLastButtonPressed() == 3)
 			return null;
 		IDoubleClickCallback callback = new IDoubleClickCallback() {
 
@@ -160,8 +169,7 @@ public abstract class TextAwareLabelEditPart extends CompartmentEditPart
 				performDirectEditRequest(request);
 			}
 		};
-		return new DoubleClickDirectEditDragTracker(this,
-				getTopGraphicEditPart(), callback);
+		return new DoubleClickDirectEditDragTracker(this, getTopGraphicEditPart(), callback);
 	}
 
 	@Override
@@ -170,13 +178,13 @@ public abstract class TextAwareLabelEditPart extends CompartmentEditPart
 		try {
 			getEditingDomain().runExclusive(new Runnable() {
 
+				@Override
 				public void run() {
 					if (isActive()) {
-						if (theRequest.getExtendedData().get(
-								REQ_DIRECTEDIT_EXTENDEDDATA_INITIAL_CHAR) instanceof Character
+						if (theRequest.getExtendedData()
+								.get(REQ_DIRECTEDIT_EXTENDEDDATA_INITIAL_CHAR) instanceof Character
 								&& manager instanceof TextDirectEditManager) {
-							Character initialChar = (Character) theRequest
-									.getExtendedData()
+							Character initialChar = (Character) theRequest.getExtendedData()
 									.get(REQ_DIRECTEDIT_EXTENDEDDATA_INITIAL_CHAR);
 
 							((TextDirectEditManager) manager).show(initialChar);

--- a/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/ISctIssueCreator.java
+++ b/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/ISctIssueCreator.java
@@ -6,11 +6,12 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * Contributors:
  * 	committers of YAKINDU - initial API and implementation
- * 
+ *
  */
 package org.yakindu.sct.model.sgraph.ui.validation;
 
 import org.eclipse.core.resources.IMarker;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.validation.Issue;
 
 import com.google.inject.ImplementedBy;
@@ -21,8 +22,9 @@ import com.google.inject.ImplementedBy;
 @ImplementedBy(SctIssueCreator.class)
 public interface ISctIssueCreator {
 
-    SCTIssue createFromMarker(IMarker marker, String elementID);
+	SCTIssue createFromMarker(IMarker marker, String elementID);
+
+	SCTIssue create(Issue t, EObject e, String uriFragment);
 
 	SCTIssue create(Issue t, String uriFragment);
-    
 }

--- a/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/SCTDiagnosticConverterImpl.java
+++ b/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/SCTDiagnosticConverterImpl.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * Contributors:
  * 	committers of YAKINDU - initial API and implementation
- * 
+ *
  */
 package org.yakindu.sct.model.sgraph.ui.validation;
 
@@ -22,18 +22,19 @@ import org.yakindu.sct.model.sgraph.SpecificationElement;
 import com.google.inject.Inject;
 
 /**
- * 
+ *
  * @author andreas muelder - Initial contribution and API
- * 
+ *
  */
 public class SCTDiagnosticConverterImpl extends DiagnosticConverterImpl {
 
 	@Inject
 	ISctIssueCreator issueCreator;
-	
+
 	@Override
 	public void convertValidatorDiagnostic(final Diagnostic diagnostic, final IAcceptor<Issue> acceptor) {
 		super.convertValidatorDiagnostic(diagnostic, new IAcceptor<Issue>() {
+			@Override
 			public void accept(Issue t) {
 				boolean notAccepted = true;
 				if (diagnostic.getData().get(0) instanceof EObject) {
@@ -43,7 +44,8 @@ public class SCTDiagnosticConverterImpl extends DiagnosticConverterImpl {
 							eObject = EcoreUtil2.getContainerOfType(eObject, SpecificationElement.class);
 						}
 						if (eObject != null && eObject.eResource() != null) {
-							acceptor.accept(issueCreator.create(t, eObject.eResource().getURIFragment(eObject)));
+							acceptor.accept(
+									issueCreator.create(t, eObject, eObject.eResource().getURIFragment(eObject)));
 							notAccepted = false;
 						}
 					}

--- a/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/SCTIssue.java
+++ b/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/SCTIssue.java
@@ -6,20 +6,21 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * Contributors:
  * 	committers of YAKINDU - initial API and implementation
- * 
+ *
  */
 package org.yakindu.sct.model.sgraph.ui.validation;
 
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.diagnostics.Severity;
 import org.eclipse.xtext.validation.CheckType;
 import org.eclipse.xtext.validation.Issue;
 import org.eclipse.xtext.validation.Issue.IssueImpl;
 
 /**
- * 
+ *
  * @author andreas muelder - Initial contribution and API
- * 
+ *
  */
 public class SCTIssue extends IssueImpl {
 
@@ -27,55 +28,76 @@ public class SCTIssue extends IssueImpl {
 
 	private final String semanticURI;
 
-	public SCTIssue(final Issue delegate, String semanticURI) {
+	private final EObject eObject;
+
+	public SCTIssue(final Issue delegate, EObject eObject, String semanticURI) {
 		this.delegate = delegate;
+		this.eObject = eObject;
 		this.semanticURI = semanticURI;
+	}
+
+	public SCTIssue(final Issue delegate, String semanticURI) {
+		this(delegate, null, semanticURI);
 	}
 
 	public String getSemanticURI() {
 		return semanticURI;
 	}
 
+	public EObject getEObject() {
+		return this.eObject;
+	}
+
+	@Override
 	public Severity getSeverity() {
 		return delegate.getSeverity();
 	}
 
+	@Override
 	public String getMessage() {
 		return delegate.getMessage();
 	}
 
+	@Override
 	public String getCode() {
 		return delegate.getCode();
 	}
 
+	@Override
 	public CheckType getType() {
 		return delegate.getType();
 	}
 
+	@Override
 	public URI getUriToProblem() {
 		return delegate.getUriToProblem();
 	}
 
+	@Override
 	public Integer getLineNumber() {
 		return delegate.getLineNumber();
 	}
 
+	@Override
 	public Integer getOffset() {
 		return delegate.getOffset();
 	}
 
+	@Override
 	public Integer getLength() {
 		return delegate.getLength();
 	}
 
+	@Override
 	public boolean isSyntaxError() {
 		return delegate.isSyntaxError();
 	}
 
+	@Override
 	public String[] getData() {
 		return delegate.getData();
 	}
-	
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;

--- a/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/SCTMarkerCreator.java
+++ b/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/SCTMarkerCreator.java
@@ -6,20 +6,23 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * Contributors:
  * 	committers of YAKINDU - initial API and implementation
- * 
+ *
  */
 package org.yakindu.sct.model.sgraph.ui.validation;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.ui.editor.validation.MarkerCreator;
 import org.eclipse.xtext.validation.Issue;
+import org.yakindu.base.base.NamedElement;
+import org.yakindu.sct.model.sgraph.SpecificationElement;
 
 /**
- * 
+ *
  * @author andreas muelder - Initial contribution and API
- * 
+ *
  */
 public class SCTMarkerCreator extends MarkerCreator {
 
@@ -28,6 +31,29 @@ public class SCTMarkerCreator extends MarkerCreator {
 		super.setMarkerAttributes(issue, resource, marker);
 		if (issue instanceof SCTIssue) {
 			marker.setAttribute(SCTMarkerType.SEMANTIC_ELEMENT_ID, ((SCTIssue) issue).getSemanticURI());
+			setIssueReason(marker, (SCTIssue) issue);
+		}
+	}
+
+	protected void setIssueReason(IMarker marker, SCTIssue issue) {
+		EObject e = issue.getEObject();
+		if (e == null) {
+			return;
+		}
+
+		if (e instanceof NamedElement && issue.getMessage().toLowerCase().contains("name")) {
+			try {
+				marker.setAttribute(SCTMarkerType.NAMEDELEMENT_NAME, true);
+			} catch (CoreException e1) {
+				e1.printStackTrace();
+			}
+		}
+		if (e instanceof SpecificationElement) {
+			try {
+				marker.setAttribute(SCTMarkerType.SPECIFICATIONELMENT_SPECIFICATION, true);
+			} catch (CoreException e1) {
+				e1.printStackTrace();
+			}
 		}
 	}
 

--- a/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/SCTMarkerCreator.java
+++ b/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/SCTMarkerCreator.java
@@ -41,7 +41,7 @@ public class SCTMarkerCreator extends MarkerCreator {
 			return;
 		}
 
-		if (e instanceof NamedElement && issue.getMessage().toLowerCase().contains("name")) {
+		if (e instanceof NamedElement && isNamingIssue(issue.getMessage())) {
 			try {
 				marker.setAttribute(SCTMarkerType.NAMEDELEMENT_NAME, true);
 			} catch (CoreException e1) {
@@ -55,6 +55,10 @@ public class SCTMarkerCreator extends MarkerCreator {
 				e1.printStackTrace();
 			}
 		}
+	}
+
+	protected boolean isNamingIssue(String message) {
+		return message.toLowerCase().contains("name") || message.toLowerCase().contains("duplicate");
 	}
 
 }

--- a/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/SCTMarkerType.java
+++ b/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/SCTMarkerType.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * Contributors:
  * 	committers of YAKINDU - initial API and implementation
- * 
+ *
  */
 package org.yakindu.sct.model.sgraph.ui.validation;
 
@@ -19,7 +19,8 @@ public interface SCTMarkerType {
 	public final static String NORMAL_VALIDATION = "org.yakindu.sct.ui.editor.diagnostic.normal"; //$NON-NLS-1$
 	public final static String EXPENSIVE_VALIDATION = "org.yakindu.sct.ui.editor.diagnostic.expensive"; //$NON-NLS-1$
 	public static final String SCT_TASK_TYPE = "org.yakindu.sct.ui.editor.task"; //$NON-NLS-1$
-	
+
 	public static final String SEMANTIC_ELEMENT_ID = org.eclipse.gmf.runtime.common.core.resources.IMarker.ELEMENT_ID;
-			
+	public static final String SPECIFICATIONELMENT_SPECIFICATION = "org.yakindu.sct.model.sgraph.SGraphPackage.SPECIFICATION_ELEMENT__SPECIFICATION";
+	public static final String NAMEDELEMENT_NAME = "org.yakindu.base.base.BasePackage.NAMED_ELEMENT__NAME";
 }

--- a/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/SctIssueCreator.java
+++ b/plugins/org.yakindu.sct.model.sgraph.ui/src/org/yakindu/sct/model/sgraph/ui/validation/SctIssueCreator.java
@@ -7,11 +7,12 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * Contributors:
  * 	committers of YAKINDU - initial API and implementation
- * 
+ *
  */
 package org.yakindu.sct.model.sgraph.ui.validation;
 
 import org.eclipse.core.resources.IMarker;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.ui.util.IssueUtil;
 import org.eclipse.xtext.validation.Issue;
 
@@ -28,11 +29,17 @@ public class SctIssueCreator implements ISctIssueCreator {
 	@Override
 	public SCTIssue createFromMarker(final IMarker marker, final String id) {
 		final Issue delegate = issueCreator.createIssue(marker);
-		return create(delegate,id);
+		return create(delegate, id);
 	}
 
+	@Override
 	public SCTIssue create(Issue delegate, String id) {
-		final SCTIssue issue = new SCTIssue(delegate, id);
+		return create(delegate, null, id);
+	}
+
+	@Override
+	public SCTIssue create(Issue delegate, EObject e, String id) {
+		final SCTIssue issue = new SCTIssue(delegate, e, id);
 		return issue;
 	}
 

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/providers/StatechartMarkerNavigationProvider.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/providers/StatechartMarkerNavigationProvider.java
@@ -6,16 +6,18 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * Contributors:
  * 	committers of YAKINDU - initial API and implementation
- * 
+ *
  */
 package org.yakindu.sct.ui.editor.providers;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.requests.DirectEditRequest;
@@ -25,15 +27,17 @@ import org.eclipse.gmf.runtime.emf.ui.providers.marker.AbstractModelMarkerNaviga
 import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.xtext.EcoreUtil2;
+import org.yakindu.base.base.BasePackage;
 import org.yakindu.base.xtext.utils.gmf.directedit.IXtextAwareEditPart;
 import org.yakindu.sct.model.sgraph.SGraphPackage;
+import org.yakindu.sct.model.sgraph.State;
 import org.yakindu.sct.model.sgraph.ui.validation.SCTMarkerType;
 import org.yakindu.sct.ui.editor.partitioning.DiagramPartitioningUtil;
 
 /**
- * 
+ *
  * @author andreas muelder
- * 
+ *
  */
 public class StatechartMarkerNavigationProvider extends AbstractModelMarkerNavigationProvider {
 
@@ -60,27 +64,67 @@ public class StatechartMarkerNavigationProvider extends AbstractModelMarkerNavig
 
 		EditPart targetEditPart = (EditPart) editPartRegistry.get(view);
 		if (targetEditPart != null) {
-			if(!targetEditPart.isSelectable()) return;
-			DiagramPartitioningUtil.selectElementsInDiagram(editor, Arrays.asList(new EditPart[] { targetEditPart }));
+			if (!targetEditPart.isSelectable())
+				return;
+			DiagramPartitioningUtil.selectElementsInDiagram(editor, Arrays.asList(new EditPart[]{targetEditPart}));
 		}
 
 		try {
 			if (marker.isSubtypeOf(SCTMarkerType.SUPERTYPE)) {
 				final DirectEditRequest request = new DirectEditRequest();
-				request.setDirectEditFeature(SGraphPackage.eINSTANCE.getSpecificationElement_Specification());
-				List<EObject> allNotationElements = EcoreUtil2.eAllContentsAsList(view);
-				for (EObject eObject : allNotationElements) {
-					if (eObject instanceof View) {
-						IGraphicalEditPart editPart = (IGraphicalEditPart) editPartRegistry.get(eObject);
-						if (editPart instanceof IXtextAwareEditPart) {
-							editPart.performRequest(request);
-						}
+				request.setDirectEditFeature(getEditFeature(targetElement, marker));
+				List<IGraphicalEditPart> allEditParts = getEditParts(editPartRegistry,
+						EcoreUtil2.eAllContentsAsList(view));
+
+				for (IGraphicalEditPart editPart : allEditParts) {
+					if (editPart instanceof IXtextAwareEditPart) {
+						editPart.performRequest(request);
 					}
 				}
 			}
 		} catch (CoreException e) {
 			e.printStackTrace();
 		}
+	}
+
+	protected List<IGraphicalEditPart> getEditParts(Map<?, ?> editPartRegistry, Iterable<EObject> eObjects) {
+		List<IGraphicalEditPart> editParts = new ArrayList<>();
+		for (EObject e : eObjects) {
+			if (e instanceof View) {
+				editParts.add((IGraphicalEditPart) editPartRegistry.get(e));
+			}
+		}
+		return editParts;
+	}
+
+	protected EAttribute getEditFeature(EObject targetObject, IMarker marker) {
+		EAttribute defaultAttr = SGraphPackage.eINSTANCE.getSpecificationElement_Specification();
+		if (targetObject == null) {
+			return defaultAttr;
+		}
+		if (targetObject instanceof State && isReasonNamedElementName(marker)) {
+			return BasePackage.eINSTANCE.getNamedElement_Name();
+		} else {
+			return defaultAttr;
+		}
+	}
+
+	protected boolean isReasonNamedElementName(IMarker marker) {
+		return containsAttribute(marker, SCTMarkerType.NAMEDELEMENT_NAME);
+	}
+
+	protected boolean isReasonSpecificationElementSpecification(IMarker marker) {
+		return containsAttribute(marker, SCTMarkerType.SPECIFICATIONELMENT_SPECIFICATION);
+	}
+
+	protected boolean containsAttribute(IMarker marker, String attributeName) {
+		try {
+			Object attribute = marker.getAttribute(attributeName);
+			return attribute != null;
+		} catch (CoreException e) {
+			e.printStackTrace();
+		}
+		return false;
 	}
 
 }

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/providers/StatechartMarkerNavigationProvider.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/providers/StatechartMarkerNavigationProvider.java
@@ -28,9 +28,10 @@ import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.xtext.EcoreUtil2;
 import org.yakindu.base.base.BasePackage;
+import org.yakindu.base.gmf.runtime.editparts.TextAwareLabelEditPart;
 import org.yakindu.base.xtext.utils.gmf.directedit.IXtextAwareEditPart;
 import org.yakindu.sct.model.sgraph.SGraphPackage;
-import org.yakindu.sct.model.sgraph.State;
+import org.yakindu.sct.model.sgraph.Vertex;
 import org.yakindu.sct.model.sgraph.ui.validation.SCTMarkerType;
 import org.yakindu.sct.ui.editor.partitioning.DiagramPartitioningUtil;
 
@@ -41,6 +42,13 @@ import org.yakindu.sct.ui.editor.partitioning.DiagramPartitioningUtil;
  */
 public class StatechartMarkerNavigationProvider extends AbstractModelMarkerNavigationProvider {
 
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.eclipse.gmf.runtime.common.ui.services.marker.
+	 * AbstractMarkerNavigationProvider#doGotoMarker(org.eclipse.core.resources.
+	 * IMarker)
+	 */
 	@Override
 	@SuppressWarnings("rawtypes")
 	protected void doGotoMarker(IMarker marker) {
@@ -77,8 +85,11 @@ public class StatechartMarkerNavigationProvider extends AbstractModelMarkerNavig
 						EcoreUtil2.eAllContentsAsList(view));
 
 				for (IGraphicalEditPart editPart : allEditParts) {
-					if (editPart instanceof IXtextAwareEditPart) {
+					if (editPart instanceof IXtextAwareEditPart
+							|| (editPart instanceof TextAwareLabelEditPart) && ((TextAwareLabelEditPart) editPart)
+									.getFeature().equals(request.getDirectEditFeature())) {
 						editPart.performRequest(request);
+						break;
 					}
 				}
 			}
@@ -102,7 +113,7 @@ public class StatechartMarkerNavigationProvider extends AbstractModelMarkerNavig
 		if (targetObject == null) {
 			return defaultAttr;
 		}
-		if (targetObject instanceof State && isReasonNamedElementName(marker)) {
+		if (targetObject instanceof Vertex && isReasonNamedElementName(marker)) {
 			return BasePackage.eINSTANCE.getNamedElement_Name();
 		} else {
 			return defaultAttr;


### PR DESCRIPTION
This fixes #185 where the error marker on a state with no name would not open its name label, but the specification section instead. Information about the underlying issue was added to the marker and some heuristics to find the correct editPart were added to the `StatechartMarkerNavigationProvider`.