### PR TITLE
Fixes #1899. Changed validation checktype for unused internal scope …

### DIFF
--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextJavaValidator.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextJavaValidator.java
@@ -287,7 +287,7 @@ public class STextJavaValidator extends AbstractSTextJavaValidator implements ST
 		}
 	}
 
-	@Check(CheckType.NORMAL)
+	@Check(CheckType.FAST)
 	public void checkUnusedVariablesInInternalScope(InternalScope internalScope) {
 		EList<Declaration> internalScopeDeclarations = internalScope.getDeclarations();
 
@@ -329,7 +329,6 @@ public class STextJavaValidator extends AbstractSTextJavaValidator implements ST
 					}
 				}
 				if (!internalDeclarationUsed) {
-
 					if (internalDeclaration instanceof VariableDefinition
 							|| internalDeclaration instanceof EventDefinition
 							|| internalDeclaration instanceof OperationDefinition)
@@ -337,7 +336,6 @@ public class STextJavaValidator extends AbstractSTextJavaValidator implements ST
 				}
 			}
 		}
-
 	}
 
 	@Check(CheckType.FAST)

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/definitionsection/StatechartDefinitionSection.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/definitionsection/StatechartDefinitionSection.java
@@ -44,7 +44,6 @@ import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.events.ControlEvent;
-import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.MouseAdapter;


### PR DESCRIPTION
…declarations from CheckType.NORMAL to CheckType.FAST because the internal embedded xtext editor code binds its xtext widget to CheckType.FAST validations only. Removed unsued imports.