### PR TITLE
Fix naming of steps

### DIFF
--- a/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/naming/ElementNameProvider.xtend
+++ b/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/naming/ElementNameProvider.xtend
@@ -26,9 +26,11 @@ import org.eclipse.xtext.naming.QualifiedName
 import org.yakindu.sct.model.sexec.Reaction
 import java.util.List
 import java.util.ArrayList
+import org.yakindu.sct.model.sexec.extensions.SExecExtensions
 
 class ElementNameProvider {
 	@Inject private StextNameProvider provider
+	@Inject protected extension SExecExtensions
 
 	def public List<String> elementNameSegments(NamedElement e) {
 		val name = elementName(e);
@@ -68,7 +70,7 @@ class ElementNameProvider {
 	}
 
 	def protected dispatch QualifiedName elementName(Reaction it) {
-		return provider.getFullyQualifiedName(it).skipFirst(2)
+		provider.getFullyQualifiedName(it).skipFirst(2)
 	}
 
 	def protected dispatch QualifiedName elementName(Region it) {
@@ -76,7 +78,12 @@ class ElementNameProvider {
 	}
 
 	def protected dispatch QualifiedName elementName(Step it) {
-		return eContainer.elementName()
+		var parentName = eContainer.elementName
+		// parent name may be null
+		if (( isEnterSequence || isCheckFunction || isEffect ) && (name !== null) && (!name.trim.empty))
+			parentName.append(name)
+		else
+			parentName
 	}
 
 	def protected dispatch QualifiedName elementName(Vertex it) {

--- a/test-plugins/org.yakindu.sct.model.sexec.test/src/org/yakindu/sct/model/sexec/transformation/test/TreeNamingServiceTest.java
+++ b/test-plugins/org.yakindu.sct.model.sexec.test/src/org/yakindu/sct/model/sexec/transformation/test/TreeNamingServiceTest.java
@@ -146,7 +146,7 @@ public class TreeNamingServiceTest extends ModelSequencerTest {
 	}
 
 	@Test
-	public void statechartTest1() {
+	public void statechartNamingBaseTest() {
 		Statechart toTest = getNamingServiceStatechart();
 
 		List<String> names = new ArrayList<>();
@@ -176,16 +176,21 @@ public class TreeNamingServiceTest extends ModelSequencerTest {
 		stringListsEqual(expectedNames, names);
 	}
 
+	/*
+	 * This test will fail if any details of the naming algorithm are changed.
+	 * It is safe to change these names to the new ones if the changes were
+	 * expected.
+	 */
 	@Test
-	public void statechartTest2() {
+	public void statechartNamingRegressionTest() {
 		Statechart toTest = getNamingServiceStatechart();
 
 		List<String> names = new ArrayList<>();
 
 		// these names are shorter than 15 characters because there are more
 		// elements containing these names, e.g. state actions
-		List<String> expectedNames = new ArrayList<>(Arrays.asList("mrgn_StA", "mrgn_StteB", "s_SA", "t_SA",
-				"t_SA_AR_SA", "t_SA_AR_StB", "s_SA_AR_SA", "s_SA_AR_StB"));
+		List<String> expectedNames = new ArrayList<>(Arrays.asList("mgn_SA", "mgn_StteB", "s_SA", "t_SA", "t_SA_AR_SA",
+				"t_SA_AR_StB", "s_SA_AR_SA", "s_SA_AR_StB"));
 
 		ExecutionFlow flow = optimizer.transform(sequencer.transform(toTest));
 


### PR DESCRIPTION
Equalizes the naming of steps in `TreeNamingService` and `DefaultNamingService`.