### PR TITLE
Fixes Nullpointer exception for some cases where the eResource for a …

### DIFF
--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextJavaValidator.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextJavaValidator.java
@@ -960,6 +960,7 @@ public class STextJavaValidator extends AbstractSTextJavaValidator implements ST
 		if (provider == null) {
 			return EcoreUtil2.getContainerOfType(context, Statechart.class);
 		} else {
+			if(provider.getElement().eResource() == null) return null;
 			return (Statechart) EcoreUtil.getObjectByType(provider.getElement().eResource().getContents(),
 					SGraphPackage.Literals.STATECHART);
 		}


### PR DESCRIPTION
…provider element was null when accessing it within the STextJavaValidator.