### PR TITLE
Fixes #1979. When switching routing options for transitions in the …

### DIFF
--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editparts/TransitionEditPart.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/editparts/TransitionEditPart.java
@@ -11,7 +11,6 @@
 package org.yakindu.sct.ui.editor.editparts;
 
 import org.eclipse.draw2d.Connection;
-import org.eclipse.draw2d.IFigure;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditPart;

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/propertysheets/appearance/TransitionAppearancePropertySection.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/propertysheets/appearance/TransitionAppearancePropertySection.java
@@ -10,11 +10,17 @@
  */
 package org.yakindu.sct.ui.editor.propertysheets.appearance;
 
+import java.util.List;
+
+import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.properties.sections.appearance.ConnectionAppearancePropertySection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.IWorkbenchPart;
 import org.yakindu.sct.ui.editor.editparts.TransitionEditPart;
+import org.yakindu.sct.ui.editor.editparts.TransitionExpressionEditPart;
 import org.yakindu.sct.ui.editor.propertysheets.util.SelectionUnwrapperUtil;
+
+import com.google.common.collect.Lists;
 
 /**
  * 
@@ -27,4 +33,20 @@ public class TransitionAppearancePropertySection extends ConnectionAppearancePro
 	public void setInput(IWorkbenchPart part, ISelection selection) {
 		super.setInput(part, SelectionUnwrapperUtil.unwrapSelectionForType(selection, TransitionEditPart.class));
 	}
+	
+	@Override
+	public List<ConnectionEditPart> getInput() {
+		List<?> elements = super.getInput();
+		List<ConnectionEditPart> connectionEditParts = Lists.newArrayList();
+		if(elements != null)
+			elements.forEach(e -> {
+				if (e instanceof TransitionExpressionEditPart) {
+					connectionEditParts.add((TransitionEditPart) ((TransitionExpressionEditPart) e).getParent());
+				}else if(e instanceof TransitionEditPart) {
+					connectionEditParts.add((TransitionEditPart) e);
+				}
+			});
+		return connectionEditParts;
+	}
+
 }


### PR DESCRIPTION
…properties section, the input is now correctly processed.