### PR TITLE
Resolves issue where keybinding conflicts occured when working with …

### DIFF
--- a/plugins/org.yakindu.sct.ui.editor/plugin.xml
+++ b/plugins/org.yakindu.sct.ui.editor/plugin.xml
@@ -924,4 +924,32 @@
           id="org.yakindu.sct.ui.editor.DiagramEditorInputFactory">
     </factory>
  </extension>
+ <extension
+       point="org.eclipse.ui.contexts">
+    <context
+          description="Embedded Xtext Editor Scope"
+          id="org.eclipse.xtext.ui.embeddedTextEditorScope"
+          name="Embedded Xtext Editor Scope"
+          parentId="org.eclipse.ui.contexts.dialogAndWindow">
+    </context>
+ </extension>
+ <extension
+       point="org.eclipse.ui.bindings">
+    <scheme
+          description="Statechart Definition Section Keybinding Configuration"
+          id="org.yakindu.sct.ui.editor.definitionsection.keybindingConfiguration"
+          name="Statechart Definition Section Keybinding Configuration"
+          parentId="org.eclipse.ui.defaultAcceleratorConfiguration">
+    </scheme>
+    <key
+          contextId="org.eclipse.xtext.ui.embeddedTextEditorScope"
+          schemeId="org.yakindu.sct.ui.editor.definitionsection.keybindingConfiguration"
+          sequence="F2">
+    </key>
+    <key
+          contextId="org.eclipse.xtext.ui.XtextEditorScope"
+          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+          sequence="M3+M1+H">
+    </key>
+ </extension>
 </plugin>


### PR DESCRIPTION
…the embedded editor.

* Disabled "F2" shortcut for embeddedTextEditorScope
* Disabled "ALT+STRG+H (Open Call Hierarchy)" shortcut for XtextEditorScope
Resolves #1973.
Fixes Yakindu/sctpro#1432