### PR TITLE
Issue 2051

### DIFF
--- a/test-plugins/org.yakindu.sct.model.sgraph.test/src/org/yakindu/sct/model/sgraph/test/SGraphJavaValidationTest.java
+++ b/test-plugins/org.yakindu.sct.model.sgraph.test/src/org/yakindu/sct/model/sgraph/test/SGraphJavaValidationTest.java
@@ -27,6 +27,7 @@ import org.eclipse.xtext.junit4.InjectWith;
 import org.eclipse.xtext.junit4.XtextRunner;
 import org.eclipse.xtext.validation.Check;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.yakindu.base.base.NamedElement;
@@ -941,5 +942,10 @@ public class SGraphJavaValidationTest {
 	}
 
 
-
+	@Test
+	@Ignore
+	public void checkOnlyOneDefaultEntryPermitted() {
+		// stub
+	}
+	
 }


### PR DESCRIPTION
Added a check for unnamed and 'default' entries. I created a new one, because I wasn't able to locate the existing one for "Duplicate Entry '???' in Region '???'".

Unit test is just a stub.