### PR TITLE
Fixing of Stext classpath

### DIFF
--- a/plugins/org.yakindu.sct.model.stext/.classpath
+++ b/plugins/org.yakindu.sct.model.stext/.classpath
@@ -3,7 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="xtend-gen"/>
 	<classpathentry kind="src" path="src-gen"/>
 	<classpathentry kind="src" path="model"/>
 	<classpathentry kind="src" path="emf-gen"/>


### PR DESCRIPTION
The src-folder xtend-gen is referenced in the classpath but does not
exists, which leads to build errors.