### PR TITLE
Make Package implement DomainElement

### DIFF
--- a/plugins/org.yakindu.base.types.edit/src/org/yakindu/base/types/provider/PackageItemProvider.java
+++ b/plugins/org.yakindu.base.types.edit/src/org/yakindu/base/types/provider/PackageItemProvider.java
@@ -19,7 +19,9 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
+import org.eclipse.emf.edit.provider.ItemPropertyDescriptor;
 import org.eclipse.emf.edit.provider.ViewerNotification;
+import org.yakindu.base.base.BasePackage;
 import org.yakindu.base.types.TypesFactory;
 import org.yakindu.base.types.TypesPackage;
 
@@ -52,9 +54,32 @@ public class PackageItemProvider
 		if (itemPropertyDescriptors == null) {
 			super.getPropertyDescriptors(object);
 
+			addDomainIDPropertyDescriptor(object);
 			addImportPropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
+	}
+
+	/**
+	 * This adds a property descriptor for the Domain ID feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addDomainIDPropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_DomainElement_domainID_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_DomainElement_domainID_feature", "_UI_DomainElement_type"),
+				 BasePackage.Literals.DOMAIN_ELEMENT__DOMAIN_ID,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
 	}
 
 	/**
@@ -92,7 +117,6 @@ public class PackageItemProvider
 		if (childrenFeatures == null) {
 			super.getChildrenFeatures(object);
 			childrenFeatures.add(TypesPackage.Literals.PACKAGE__MEMBER);
-			childrenFeatures.add(TypesPackage.Literals.PACKAGE__DOMAIN);
 		}
 		return childrenFeatures;
 	}
@@ -147,8 +171,10 @@ public class PackageItemProvider
 		updateChildren(notification);
 
 		switch (notification.getFeatureID(org.yakindu.base.types.Package.class)) {
+			case TypesPackage.PACKAGE__DOMAIN_ID:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
 			case TypesPackage.PACKAGE__MEMBER:
-			case TypesPackage.PACKAGE__DOMAIN:
 				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
 				return;
 		}
@@ -230,11 +256,6 @@ public class PackageItemProvider
 			(createChildParameter
 				(TypesPackage.Literals.PACKAGE__MEMBER,
 				 TypesFactory.eINSTANCE.createAnnotationType()));
-
-		newChildDescriptors.add
-			(createChildParameter
-				(TypesPackage.Literals.PACKAGE__DOMAIN,
-				 TypesFactory.eINSTANCE.createDomain()));
 	}
 
 }

--- a/plugins/org.yakindu.base.types/model/types.ecore
+++ b/plugins/org.yakindu.base.types/model/types.ecore
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="types" nsURI="http://www.yakindu.org/base/types/2.0.0" nsPrefix="types">
-  <eClassifiers xsi:type="ecore:EClass" name="Package" eSuperTypes="#//PackageMember">
+  <eClassifiers xsi:type="ecore:EClass" name="Package" eSuperTypes="#//PackageMember base.ecore#//DomainElement">
     <eStructuralFeatures xsi:type="ecore:EReference" name="member" upperBound="-1"
         eType="#//PackageMember" containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="domain" eType="#//Domain"
-        containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="import" upperBound="-1"
         eType="#//Package"/>
   </eClassifiers>

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/Package.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/Package.java
@@ -3,6 +3,7 @@
 package org.yakindu.base.types;
 
 import org.eclipse.emf.common.util.EList;
+import org.yakindu.base.base.DomainElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -14,7 +15,6 @@ import org.eclipse.emf.common.util.EList;
  * </p>
  * <ul>
  *   <li>{@link org.yakindu.base.types.Package#getMember <em>Member</em>}</li>
- *   <li>{@link org.yakindu.base.types.Package#getDomain <em>Domain</em>}</li>
  *   <li>{@link org.yakindu.base.types.Package#getImport <em>Import</em>}</li>
  * </ul>
  *
@@ -22,7 +22,7 @@ import org.eclipse.emf.common.util.EList;
  * @model
  * @generated
  */
-public interface Package extends PackageMember {
+public interface Package extends PackageMember, DomainElement {
 	/**
 	 * Returns the value of the '<em><b>Member</b></em>' containment reference list.
 	 * The list contents are of type {@link org.yakindu.base.types.PackageMember}.
@@ -38,32 +38,6 @@ public interface Package extends PackageMember {
 	 * @generated
 	 */
 	EList<PackageMember> getMember();
-
-	/**
-	 * Returns the value of the '<em><b>Domain</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Domain</em>' reference isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
-	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Domain</em>' containment reference.
-	 * @see #setDomain(Domain)
-	 * @see org.yakindu.base.types.TypesPackage#getPackage_Domain()
-	 * @model containment="true"
-	 * @generated
-	 */
-	Domain getDomain();
-
-	/**
-	 * Sets the value of the '{@link org.yakindu.base.types.Package#getDomain <em>Domain</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Domain</em>' containment reference.
-	 * @see #getDomain()
-	 * @generated
-	 */
-	void setDomain(Domain value);
 
 	/**
 	 * Returns the value of the '<em><b>Import</b></em>' reference list.

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/TypesPackage.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/TypesPackage.java
@@ -145,22 +145,22 @@ public interface TypesPackage extends EPackage {
 	int PACKAGE__ANNOTATIONS = PACKAGE_MEMBER__ANNOTATIONS;
 
 	/**
+	 * The feature id for the '<em><b>Domain ID</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PACKAGE__DOMAIN_ID = PACKAGE_MEMBER_FEATURE_COUNT + 0;
+
+	/**
 	 * The feature id for the '<em><b>Member</b></em>' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int PACKAGE__MEMBER = PACKAGE_MEMBER_FEATURE_COUNT + 0;
-
-	/**
-	 * The feature id for the '<em><b>Domain</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int PACKAGE__DOMAIN = PACKAGE_MEMBER_FEATURE_COUNT + 1;
+	int PACKAGE__MEMBER = PACKAGE_MEMBER_FEATURE_COUNT + 1;
 
 	/**
 	 * The feature id for the '<em><b>Import</b></em>' reference list.
@@ -1650,17 +1650,6 @@ public interface TypesPackage extends EPackage {
 	EReference getPackage_Member();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link org.yakindu.base.types.Package#getDomain <em>Domain</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference '<em>Domain</em>'.
-	 * @see org.yakindu.base.types.Package#getDomain()
-	 * @see #getPackage()
-	 * @generated
-	 */
-	EReference getPackage_Domain();
-
-	/**
 	 * Returns the meta object for the reference list '{@link org.yakindu.base.types.Package#getImport <em>Import</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2324,14 +2313,6 @@ public interface TypesPackage extends EPackage {
 		 * @generated
 		 */
 		EReference PACKAGE__MEMBER = eINSTANCE.getPackage_Member();
-
-		/**
-		 * The meta object literal for the '<em><b>Domain</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
-		 * @generated
-		 */
-		EReference PACKAGE__DOMAIN = eINSTANCE.getPackage_Domain();
 
 		/**
 		 * The meta object literal for the '<em><b>Import</b></em>' reference list feature.

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/impl/PackageImpl.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/impl/PackageImpl.java
@@ -13,7 +13,8 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.EObjectResolvingEList;
 import org.eclipse.emf.ecore.util.InternalEList;
-import org.yakindu.base.types.Domain;
+import org.yakindu.base.base.BasePackage;
+import org.yakindu.base.base.DomainElement;
 import org.yakindu.base.types.PackageMember;
 import org.yakindu.base.types.TypesPackage;
 
@@ -25,14 +26,32 @@ import org.yakindu.base.types.TypesPackage;
  * The following features are implemented:
  * </p>
  * <ul>
+ *   <li>{@link org.yakindu.base.types.impl.PackageImpl#getDomainID <em>Domain ID</em>}</li>
  *   <li>{@link org.yakindu.base.types.impl.PackageImpl#getMember <em>Member</em>}</li>
- *   <li>{@link org.yakindu.base.types.impl.PackageImpl#getDomain <em>Domain</em>}</li>
  *   <li>{@link org.yakindu.base.types.impl.PackageImpl#getImport <em>Import</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class PackageImpl extends PackageMemberImpl implements org.yakindu.base.types.Package {
+	/**
+	 * The default value of the '{@link #getDomainID() <em>Domain ID</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getDomainID()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String DOMAIN_ID_EDEFAULT = "org.yakindu.domain.default";
+	/**
+	 * The cached value of the '{@link #getDomainID() <em>Domain ID</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getDomainID()
+	 * @generated
+	 * @ordered
+	 */
+	protected String domainID = DOMAIN_ID_EDEFAULT;
 	/**
 	 * The cached value of the '{@link #getMember() <em>Member</em>}' containment reference list.
 	 * <!-- begin-user-doc -->
@@ -42,15 +61,6 @@ public class PackageImpl extends PackageMemberImpl implements org.yakindu.base.t
 	 * @ordered
 	 */
 	protected EList<PackageMember> member;
-	/**
-	 * The cached value of the '{@link #getDomain() <em>Domain</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see #getDomain()
-	 * @generated
-	 * @ordered
-	 */
-	protected Domain domain;
 	/**
 	 * The cached value of the '{@link #getImport() <em>Import</em>}' reference list.
 	 * <!-- begin-user-doc -->
@@ -84,54 +94,32 @@ public class PackageImpl extends PackageMemberImpl implements org.yakindu.base.t
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public String getDomainID() {
+		return domainID;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setDomainID(String newDomainID) {
+		String oldDomainID = domainID;
+		domainID = newDomainID;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, TypesPackage.PACKAGE__DOMAIN_ID, oldDomainID, domainID));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EList<PackageMember> getMember() {
 		if (member == null) {
 			member = new EObjectContainmentEList<PackageMember>(PackageMember.class, this, TypesPackage.PACKAGE__MEMBER);
 		}
 		return member;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public Domain getDomain() {
-		return domain;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public NotificationChain basicSetDomain(Domain newDomain, NotificationChain msgs) {
-		Domain oldDomain = domain;
-		domain = newDomain;
-		if (eNotificationRequired()) {
-			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, TypesPackage.PACKAGE__DOMAIN, oldDomain, newDomain);
-			if (msgs == null) msgs = notification; else msgs.add(notification);
-		}
-		return msgs;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public void setDomain(Domain newDomain) {
-		if (newDomain != domain) {
-			NotificationChain msgs = null;
-			if (domain != null)
-				msgs = ((InternalEObject)domain).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - TypesPackage.PACKAGE__DOMAIN, null, msgs);
-			if (newDomain != null)
-				msgs = ((InternalEObject)newDomain).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - TypesPackage.PACKAGE__DOMAIN, null, msgs);
-			msgs = basicSetDomain(newDomain, msgs);
-			if (msgs != null) msgs.dispatch();
-		}
-		else if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, TypesPackage.PACKAGE__DOMAIN, newDomain, newDomain));
 	}
 
 	/**
@@ -156,8 +144,6 @@ public class PackageImpl extends PackageMemberImpl implements org.yakindu.base.t
 		switch (featureID) {
 			case TypesPackage.PACKAGE__MEMBER:
 				return ((InternalEList<?>)getMember()).basicRemove(otherEnd, msgs);
-			case TypesPackage.PACKAGE__DOMAIN:
-				return basicSetDomain(null, msgs);
 		}
 		return super.eInverseRemove(otherEnd, featureID, msgs);
 	}
@@ -170,10 +156,10 @@ public class PackageImpl extends PackageMemberImpl implements org.yakindu.base.t
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
+			case TypesPackage.PACKAGE__DOMAIN_ID:
+				return getDomainID();
 			case TypesPackage.PACKAGE__MEMBER:
 				return getMember();
-			case TypesPackage.PACKAGE__DOMAIN:
-				return getDomain();
 			case TypesPackage.PACKAGE__IMPORT:
 				return getImport();
 		}
@@ -189,12 +175,12 @@ public class PackageImpl extends PackageMemberImpl implements org.yakindu.base.t
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
+			case TypesPackage.PACKAGE__DOMAIN_ID:
+				setDomainID((String)newValue);
+				return;
 			case TypesPackage.PACKAGE__MEMBER:
 				getMember().clear();
 				getMember().addAll((Collection<? extends PackageMember>)newValue);
-				return;
-			case TypesPackage.PACKAGE__DOMAIN:
-				setDomain((Domain)newValue);
 				return;
 			case TypesPackage.PACKAGE__IMPORT:
 				getImport().clear();
@@ -212,11 +198,11 @@ public class PackageImpl extends PackageMemberImpl implements org.yakindu.base.t
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
+			case TypesPackage.PACKAGE__DOMAIN_ID:
+				setDomainID(DOMAIN_ID_EDEFAULT);
+				return;
 			case TypesPackage.PACKAGE__MEMBER:
 				getMember().clear();
-				return;
-			case TypesPackage.PACKAGE__DOMAIN:
-				setDomain((Domain)null);
 				return;
 			case TypesPackage.PACKAGE__IMPORT:
 				getImport().clear();
@@ -233,14 +219,62 @@ public class PackageImpl extends PackageMemberImpl implements org.yakindu.base.t
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
+			case TypesPackage.PACKAGE__DOMAIN_ID:
+				return DOMAIN_ID_EDEFAULT == null ? domainID != null : !DOMAIN_ID_EDEFAULT.equals(domainID);
 			case TypesPackage.PACKAGE__MEMBER:
 				return member != null && !member.isEmpty();
-			case TypesPackage.PACKAGE__DOMAIN:
-				return domain != null;
 			case TypesPackage.PACKAGE__IMPORT:
 				return import_ != null && !import_.isEmpty();
 		}
 		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public int eBaseStructuralFeatureID(int derivedFeatureID, Class<?> baseClass) {
+		if (baseClass == DomainElement.class) {
+			switch (derivedFeatureID) {
+				case TypesPackage.PACKAGE__DOMAIN_ID: return BasePackage.DOMAIN_ELEMENT__DOMAIN_ID;
+				default: return -1;
+			}
+		}
+		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public int eDerivedStructuralFeatureID(int baseFeatureID, Class<?> baseClass) {
+		if (baseClass == DomainElement.class) {
+			switch (baseFeatureID) {
+				case BasePackage.DOMAIN_ELEMENT__DOMAIN_ID: return TypesPackage.PACKAGE__DOMAIN_ID;
+				default: return -1;
+			}
+		}
+		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		if (eIsProxy()) return super.toString();
+
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (domainID: ");
+		result.append(domainID);
+		result.append(')');
+		return result.toString();
 	}
 
 } //PackageImpl

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/impl/TypesPackageImpl.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/impl/TypesPackageImpl.java
@@ -299,17 +299,8 @@ public class TypesPackageImpl extends EPackageImpl implements TypesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EReference getPackage_Domain() {
-		return (EReference)packageEClass.getEStructuralFeatures().get(1);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
 	public EReference getPackage_Import() {
-		return (EReference)packageEClass.getEStructuralFeatures().get(2);
+		return (EReference)packageEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
@@ -844,7 +835,6 @@ public class TypesPackageImpl extends EPackageImpl implements TypesPackage {
 		// Create classes and their features
 		packageEClass = createEClass(PACKAGE);
 		createEReference(packageEClass, PACKAGE__MEMBER);
-		createEReference(packageEClass, PACKAGE__DOMAIN);
 		createEReference(packageEClass, PACKAGE__IMPORT);
 
 		typeEClass = createEClass(TYPE);
@@ -962,6 +952,7 @@ public class TypesPackageImpl extends EPackageImpl implements TypesPackage {
 
 		// Add supertypes to classes
 		packageEClass.getESuperTypes().add(this.getPackageMember());
+		packageEClass.getESuperTypes().add(theBasePackage.getDomainElement());
 		typeEClass.getESuperTypes().add(this.getPackageMember());
 		declarationEClass.getESuperTypes().add(this.getTypedElement());
 		declarationEClass.getESuperTypes().add(theBasePackage.getNamedElement());
@@ -991,7 +982,6 @@ public class TypesPackageImpl extends EPackageImpl implements TypesPackage {
 		// Initialize classes and features; add operations and parameters
 		initEClass(packageEClass, org.yakindu.base.types.Package.class, "Package", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getPackage_Member(), this.getPackageMember(), null, "member", null, 0, -1, org.yakindu.base.types.Package.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getPackage_Domain(), this.getDomain(), null, "domain", null, 0, 1, org.yakindu.base.types.Package.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getPackage_Import(), this.getPackage(), null, "import", null, 0, -1, org.yakindu.base.types.Package.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(typeEClass, Type.class, "Type", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/util/TypesAdapterFactory.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/util/TypesAdapterFactory.java
@@ -10,6 +10,7 @@ import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.common.notify.impl.AdapterFactoryImpl;
 import org.eclipse.emf.ecore.EObject;
+import org.yakindu.base.base.DomainElement;
 import org.yakindu.base.base.NamedElement;
 import org.yakindu.base.types.AnnotatableElement;
 import org.yakindu.base.types.Annotation;
@@ -190,6 +191,10 @@ public class TypesAdapterFactory extends AdapterFactoryImpl {
 				return createNamedElementAdapter();
 			}
 			@Override
+			public Adapter caseDomainElement(DomainElement object) {
+				return createDomainElementAdapter();
+			}
+			@Override
 			public Adapter defaultCase(EObject object) {
 				return createEObjectAdapter();
 			}
@@ -336,6 +341,20 @@ public class TypesAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	public Adapter createNamedElementAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.yakindu.base.base.DomainElement <em>Domain Element</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.yakindu.base.base.DomainElement
+	 * @generated
+	 */
+	public Adapter createDomainElementAdapter() {
 		return null;
 	}
 

--- a/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/util/TypesSwitch.java
+++ b/plugins/org.yakindu.base.types/src-gen/org/yakindu/base/types/util/TypesSwitch.java
@@ -9,6 +9,7 @@ package org.yakindu.base.types.util;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.util.Switch;
+import org.yakindu.base.base.DomainElement;
 import org.yakindu.base.base.NamedElement;
 import org.yakindu.base.types.AnnotatableElement;
 import org.yakindu.base.types.Annotation;
@@ -92,6 +93,7 @@ public class TypesSwitch<T> extends Switch<T> {
 				org.yakindu.base.types.Package package_ = (org.yakindu.base.types.Package)theEObject;
 				T result = casePackage(package_);
 				if (result == null) result = casePackageMember(package_);
+				if (result == null) result = caseDomainElement(package_);
 				if (result == null) result = caseNamedElement(package_);
 				if (result == null) result = caseAnnotatableElement(package_);
 				if (result == null) result = defaultCase(theEObject);
@@ -431,6 +433,21 @@ public class TypesSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	public T caseNamedElement(NamedElement object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Domain Element</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Domain Element</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseDomainElement(DomainElement object) {
 		return null;
 	}
 


### PR DESCRIPTION
Package model element does not hold a reference to a domain anymore but instead implements from DomainElement, so it holds a domain ID.

Fixes #2114 