### PR TITLE
do not add unused import declarations to execution flow

### DIFF
--- a/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/transformation/StructureMapping.xtend
+++ b/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/transformation/StructureMapping.xtend
@@ -63,7 +63,10 @@ class StructureMapping {
 	 * @return A set of used declaration that are imported from an external resource
 	 */
 	def protected importedDeclarations(Statechart it) {
-		it.eAllContents.filter(ElementReferenceExpression).map[reference].filter(Declaration).filter[decl|!decl.eResource.URI.equals(it.eResource.URI)].toSet
+		val allDeclarations = it.eAllContents.filter(ElementReferenceExpression).map[reference].filter(Declaration).toSet
+		return if(it.eResource !== null)
+			allDeclarations.filter[decl|!decl.eResource.URI.equals(it.eResource.URI)].toSet
+		else allDeclarations
 	}
 	
 	

--- a/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/transformation/StructureMapping.xtend
+++ b/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/transformation/StructureMapping.xtend
@@ -12,12 +12,13 @@ package org.yakindu.sct.model.sexec.transformation
 
 import com.google.inject.Inject
 import java.util.ArrayList
-import org.eclipse.emf.ecore.resource.URIConverter
+import java.util.Set
+import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtext.EcoreUtil2
 import org.eclipse.xtext.naming.IQualifiedNameProvider
+import org.yakindu.base.expressions.expressions.ElementReferenceExpression
 import org.yakindu.base.types.Declaration
 import org.yakindu.base.types.Operation
-import org.yakindu.base.types.Package
 import org.yakindu.base.types.Property
 import org.yakindu.sct.model.sexec.ExecutionFlow
 import org.yakindu.sct.model.sexec.ExecutionRegion
@@ -32,20 +33,16 @@ import org.yakindu.sct.model.sgraph.Scope
 import org.yakindu.sct.model.sgraph.State
 import org.yakindu.sct.model.sgraph.Statechart
 import org.yakindu.sct.model.sgraph.Vertex
-import org.yakindu.sct.model.stext.scoping.IPackageImport2URIMapper
 import org.yakindu.sct.model.stext.stext.EventDefinition
 import org.yakindu.sct.model.stext.stext.ImportScope
 import org.yakindu.sct.model.stext.stext.OperationDefinition
 import org.yakindu.sct.model.stext.stext.VariableDefinition
-import org.eclipse.emf.ecore.EObject
 
 class StructureMapping {
 	 
 	@Inject extension SexecElementMapping mapping
 	@Inject extension StatechartExtensions sct
 	@Inject extension IQualifiedNameProvider
-	@Inject
-	private IPackageImport2URIMapper mapper;
 	
 	
 	//==========================================================================
@@ -57,15 +54,23 @@ class StructureMapping {
 	 * This includes creating the scopes and adding all relevant declarations. Empty scopes wont be mapped.
 	 */
 	def ExecutionFlow mapScopes(Statechart sc, ExecutionFlow flow) {
-		flow.scopes.addAll(sc.scopes.map(scope | scope.mapScope))
+		val usedDeclarations = sc.importedDeclarations
+		flow.scopes.addAll(sc.scopes.map(scope | scope.mapScope(usedDeclarations)))
 		flow
+	}
+	
+	/**
+	 * @return A set of used declaration that are imported from an external resource
+	 */
+	def protected importedDeclarations(Statechart it) {
+		it.eAllContents.filter(ElementReferenceExpression).map[reference].filter(Declaration).filter[decl|!decl.eResource.URI.equals(it.eResource.URI)].toSet
 	}
 	
 	
 	/**
 	 *  Interface and internal scopes have declarations
 	 */
-	def dispatch Scope mapScope(Scope scope) {
+	def dispatch Scope mapScope(Scope scope, Set<Declaration> usedDeclarationss) {
 		val _scope = scope.createScope
 		_scope.declarations.addAll(scope.declarations.map(decl | decl.map).filterNull)
 		return _scope
@@ -74,17 +79,9 @@ class StructureMapping {
 	/**
 	 * Import scope has imports which needs to be resolved to get all imported variable and operation definitions
 	 */
-	def dispatch Scope mapScope(ImportScope scope) {
+	def dispatch Scope mapScope(ImportScope scope, Set<Declaration> usedDeclarations) {
 		val _scope = scope.createScope
-		for (String importString : scope.imports){
-			val pkgImport = mapper.findPackageImport(scope.eResource,importString)
-			
-			if (pkgImport.isPresent && URIConverter.INSTANCE.exists(pkgImport.get.getUri(), null)) {
-				val packageForNamespace = scope.eResource.resourceSet.getResource(pkgImport.get.uri, true).contents.
-					head as Package
-				packageForNamespace.member.filter(Declaration).toList.forEach[createImportDeclaration(_scope)]
-			}
-		}
+		usedDeclarations.forEach[createImportDeclaration(_scope)]
 		return _scope
 	}
 	
@@ -111,17 +108,14 @@ class StructureMapping {
 	}
 	
 	def dispatch Declaration map(EventDefinition e) {
-		val _e = e.create
-		return _e
+		e.create
 	}
 	
 	def dispatch Declaration map(VariableDefinition v) {
-		val _v = v.create
-		return _v
+		v.create
 	}
 	def dispatch Declaration map(OperationDefinition v) {
-		val _v = v.create
-		return _v
+		v.create
 	}
 	 
 	

--- a/test-plugins/org.yakindu.sct.model.sexec.test/src/org/yakindu/sct/model/sexec/transformation/test/ModelSequencerTest.java
+++ b/test-plugins/org.yakindu.sct.model.sexec.test/src/org/yakindu/sct/model/sexec/transformation/test/ModelSequencerTest.java
@@ -37,7 +37,7 @@ import com.google.inject.name.Names;
  * @author axel terfloth
  *
  */
-public class ModelSequencerTest extends Assert {
+public abstract class ModelSequencerTest extends Assert {
 
 	@Inject
 	protected IModelSequencer sequencer;

--- a/test-plugins/org.yakindu.sct.model.sexec.test/src/org/yakindu/sct/model/sexec/transformation/test/ModelSequencertDeclarationsTest.java
+++ b/test-plugins/org.yakindu.sct.model.sexec.test/src/org/yakindu/sct/model/sexec/transformation/test/ModelSequencertDeclarationsTest.java
@@ -52,6 +52,8 @@ import org.yakindu.sct.model.stext.stext.OperationDefinition;
 import org.yakindu.sct.model.stext.stext.ReactionEffect;
 import org.yakindu.sct.model.stext.stext.ReactionTrigger;
 import org.yakindu.sct.model.stext.stext.VariableDefinition;
+
+import com.google.common.collect.Sets;
 public class ModelSequencertDeclarationsTest extends ModelSequencerTest {
 
 	/**
@@ -60,7 +62,7 @@ public class ModelSequencertDeclarationsTest extends ModelSequencerTest {
 	@Test
 	public void testScopeName() {
 		InterfaceScope scope = _createInterfaceScope("abc", null);
-		assertEquals(scope.getName(), ((InterfaceScope) structureMapping.mapScope(scope)).getName());
+		assertEquals(scope.getName(), ((InterfaceScope) structureMapping.mapScope(scope, Sets.newHashSet())).getName());
 	}
 
 	/**
@@ -69,7 +71,7 @@ public class ModelSequencertDeclarationsTest extends ModelSequencerTest {
 	@Test
 	public void testMapEmptyInternalScope() {
 		InternalScope scope = _createInternalScope(null);
-		Scope _scope = structureMapping.mapScope(scope);
+		Scope _scope = structureMapping.mapScope(scope, Sets.newHashSet());
 
 		assertTrue(_scope instanceof InternalScope);
 	}
@@ -83,7 +85,7 @@ public class ModelSequencertDeclarationsTest extends ModelSequencerTest {
 		EventDefinition e2 = _createEventDefinition("e2", scope);
 		VariableDefinition v1 = _createVariableDefinition("v1", TYPE_INTEGER, scope);
 
-		Scope _scope = structureMapping.mapScope(scope);
+		Scope _scope = structureMapping.mapScope(scope, Sets.newHashSet());
 
 		assertTrue(_scope instanceof InterfaceScope);
 		assertEquals(3, _scope.getDeclarations().size());


### PR DESCRIPTION
improves code generation performance / simulation performance for models
that import a lot of external declarations with only a few used.