### PR TITLE
refresh on file before request exclusive access to EditingDomain

### DIFF
--- a/plugins/org.yakindu.sct.model.stext.ui/src/org/yakindu/sct/model/stext/ui/document/TransactionalXtextDocument.java
+++ b/plugins/org.yakindu.sct.model.stext.ui/src/org/yakindu/sct/model/stext/ui/document/TransactionalXtextDocument.java
@@ -127,5 +127,13 @@ public class TransactionalXtextDocument extends ParallelReadXtextDocument {
 		}
 		return super.modify(new UnitOfWorkOnTransactionalEditingDomain<T>(work)); 
 	}
+	
+	@Override
+	public <T> T internalModify(IUnitOfWork<T, XtextResource> work) {
+		if (work instanceof CancelableUnitOfWork) {
+			return super.internalModify(new CancelableUnitOfWorkOnTransactionalEditingDomain<T>((CancelableUnitOfWork<T, XtextResource>) work));
+		}
+		return super.internalModify(new UnitOfWorkOnTransactionalEditingDomain<T>(work)); 
+	}
 
 }

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/scoping/ImportedResourceCache.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/scoping/ImportedResourceCache.java
@@ -10,6 +10,13 @@
  */
 package org.yakindu.sct.model.stext.scoping;
 
+import static org.yakindu.sct.model.stext.scoping.SharedEditingDomainFactory.DOMAIN_ID;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -21,7 +28,6 @@ import org.eclipse.xtext.resource.IResourceServiceProvider;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import static org.yakindu.sct.model.stext.scoping.SharedEditingDomainFactory.*;
 
 /**
  * 
@@ -39,6 +45,7 @@ public class ImportedResourceCache {
 	}
 
 	public IResourceDescription get(final URI uri) {
+		refreshFile(uri);
 		try {
 			return (IResourceDescription) getEditingDomain()
 					.runExclusive(new RunnableWithResult.Impl<IResourceDescription>() {
@@ -64,6 +71,21 @@ public class ImportedResourceCache {
 		} catch (InterruptedException e) {
 			e.printStackTrace();
 			return null;
+		}
+	}
+
+	/**
+	 * Refresh local file to avoid deadlock with scheduling rule XtextBuilder ->
+	 * Editing Domain runexclusive
+	 */
+	protected void refreshFile(final URI uri) {
+		IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(uri.toPlatformString(true)));
+		if (file.isAccessible() && !file.isSynchronized(IResource.DEPTH_INFINITE)) {
+			try {
+				file.refreshLocal(IResource.DEPTH_INFINITE, null);
+			} catch (CoreException e) {
+				e.printStackTrace();
+			}
 		}
 	}
 


### PR DESCRIPTION
Otherwise, if the file state is not synchronized the refresh would be
done within the exclusive editing domain. This can result in Deadlocks
with the XTextbuilder since the IScheduling Rule for the Jobs is the
same.