### PR TITLE
use windows style paths for scc parameter options

### DIFF
--- a/plugins/org.yakindu.sct.doc.user/src/user-guide/generating_code_headless.textile
+++ b/plugins/org.yakindu.sct.doc.user/src/user-guide/generating_code_headless.textile
@@ -114,7 +114,7 @@ Within the root folder of your YAKINDU Statechart Tools installation enter one o
 Windows:
 
 bc. 
-scc -d [pathToBasedir] -m project1/default.sgen,project2/default.sct
+scc -d [pathToBasedir] -m project1\default.sgen,project2\default.sct
 
 Linux:
 


### PR DESCRIPTION
In Windows paths, usually a `\` is used to separate directories from each other. Powershell understands also `/`, but cmd.exe does not. Therefore, it makes sense to change the path style to use `\`.