### PR TITLE
Fix import-string Content Assist

### DIFF
--- a/plugins/org.yakindu.sct.model.stext.ui/src/org/yakindu/sct/model/stext/ui/contentassist/STextProposalProvider.java
+++ b/plugins/org.yakindu.sct.model.stext.ui/src/org/yakindu/sct/model/stext/ui/contentassist/STextProposalProvider.java
@@ -41,7 +41,6 @@ import org.eclipse.xtext.ui.editor.contentassist.ConfigurableCompletionProposal;
 import org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext;
 import org.eclipse.xtext.ui.editor.contentassist.ContentProposalLabelProvider;
 import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor;
-import org.eclipse.xtext.ui.editor.contentassist.PrefixMatcher;
 import org.yakindu.base.expressions.expressions.ElementReferenceExpression;
 import org.yakindu.base.expressions.expressions.FeatureCall;
 import org.yakindu.base.types.Operation;
@@ -76,9 +75,9 @@ import com.google.inject.Inject;
  * @author muehlbrandt
  */
 public class STextProposalProvider extends AbstractSTextProposalProvider {
-
+	
 	protected static final String ICONS_INCLUDE = "icons/Package.png";
-
+	
 	@Inject
 	protected STextGrammarAccess grammarAccess;
 	private ComposedAdapterFactory composedAdapterFactory = new ComposedAdapterFactory(
@@ -88,26 +87,26 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 	private ILabelProvider labelProvider;
 	@Inject
 	private IPackageImport2URIMapper mapper;
-
+	
 	@Inject
 	private STextExtensions utils;
-
+	
 	public static class StrikeThroughStyler extends Styler {
-
+		
 		@Override
 		public void applyStyles(TextStyle textStyle) {
 			textStyle.strikeout = true;
 		}
 	}
-
+	
 	public static class GreyoutStyler extends Styler {
-
+		
 		@Override
 		public void applyStyles(TextStyle textStyle) {
 			textStyle.foreground = Display.getDefault().getSystemColor(SWT.COLOR_GRAY);
 		}
 	}
-
+	
 	/**
 	 * Validates if a keyword should be viewed by the proposal view.
 	 *
@@ -118,7 +117,7 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 	public void completeKeyword(Keyword keyword, ContentAssistContext contentAssistContext,
 			ICompletionProposalAcceptor acceptor) {
 		List<Keyword> suppressKeywords = new ArrayList<>();
-
+		
 		EObject rootModel = contentAssistContext.getRootModel();
 		if (rootModel instanceof TransitionSpecification) {
 			suppressKeywords(suppressKeywords, (TransitionSpecification) rootModel);
@@ -127,12 +126,12 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 		} else if (rootModel instanceof StatechartSpecification) {
 			suppressKeywords(suppressKeywords, (StatechartSpecification) rootModel);
 		}
-
+		
 		EObject currentModel = contentAssistContext.getCurrentModel();
 		if (currentModel instanceof InterfaceScope) {
 			suppressKeywords(suppressKeywords, (InterfaceScope) currentModel);
 		}
-
+		
 		if (currentModel instanceof FeatureCall) {
 			suppressKeywords(suppressKeywords, (FeatureCall) currentModel);
 		}
@@ -142,13 +141,13 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 		if (currentModel instanceof InternalScope) {
 			suppressKeywords(suppressKeywords, (InternalScope) currentModel);
 		}
-
+		
 		if (!suppressKeywords.contains(keyword)) {
 			super.completeKeyword(keyword, contentAssistContext, new AcceptorDelegate(acceptor));
-
+			
 		}
 	}
-
+	
 	// context Transition
 	protected void suppressKeywords(List<Keyword> suppressKeywords, TransitionSpecification model) {
 		suppressKeywords.addAll(getKeywords(grammarAccess.getEntryEventAccess().getGroup().eContents()));
@@ -157,7 +156,7 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 		suppressKeywords.addAll(getKeywords(grammarAccess.getExitEventAccess().getExitEventAction_0().eContents()));
 		suppressKeywords.addAll(getKeywords(grammarAccess.getExitEventAccess().getExitKeyword_1().eContents()));
 	}
-
+	
 	// context States
 	protected void suppressKeywords(List<Keyword> suppressKeywords, SimpleScope model) {
 		suppressKeywords.addAll(getKeywords(grammarAccess.getVariableDefinitionAccess().getGroup().eContents()));
@@ -165,7 +164,7 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 		suppressKeywords.addAll(getKeywords(grammarAccess.getDirectionAccess().getAlternatives().eContents()));
 		suppressKeywords.addAll(getKeywords(grammarAccess.getOperationDefinitionAccess().getGroup().eContents()));
 	}
-
+	
 	// context Statechart
 	protected void suppressKeywords(List<Keyword> suppressKeywords, StatechartSpecification model) {
 		suppressKeywords.addAll(getKeywords(grammarAccess.getExitEventAccess().getGroup().eContents()));
@@ -174,34 +173,34 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 		importKeyWordList.add(grammarAccess.getImportScopeAccess().getImportKeyword_1());
 		suppressKeywords.addAll(getKeywords(importKeyWordList));
 	}
-
+	
 	protected void suppressKeywords(List<Keyword> suppressKeywords, InterfaceScope model) {
 		suppressKeywords.addAll(getKeywords(grammarAccess.getLocalReactionAccess().getGroup().eContents()));
 		suppressKeywords.addAll(getKeywords(grammarAccess.getAlwaysEventAccess().getGroup().eContents()));
 		suppressKeywords.addAll(getKeywords(grammarAccess.getTimeEventTypeAccess().getAlternatives().eContents()));
 		suppressKeywords.add(grammarAccess.getDirectionAccess().getLOCALLocalKeyword_0_0());
 	}
-
+	
 	protected void suppressKeywords(List<Keyword> suppressKeywords, FeatureCall featureCall) {
 		if (!(featureCall.getFeature() instanceof Operation)) {
 			suppressKeywords
 			.add(grammarAccess.getFeatureCallAccess().getOperationCallLeftParenthesisKeyword_1_3_0_0_0());
 		}
 	}
-
+	
 	protected void suppressKeywords(List<Keyword> suppressKeywords, ElementReferenceExpression referenceExpression) {
 		if (!(referenceExpression.getReference() instanceof Operation)) {
 			suppressKeywords.add(grammarAccess.getElementReferenceExpressionAccess()
 					.getOperationCallLeftParenthesisKeyword_2_0_0_0());
 		}
 	}
-
+	
 	protected void suppressKeywords(List<Keyword> suppressKeywords, InternalScope model) {
 		suppressKeywords.add(grammarAccess.getDirectionAccess().getLOCALLocalKeyword_0_0());
 		suppressKeywords.add(grammarAccess.getDirectionAccess().getINInKeyword_1_0());
 		suppressKeywords.add(grammarAccess.getDirectionAccess().getOUTOutKeyword_2_0());
 	}
-
+	
 	protected List<Keyword> getKeywords(EList<EObject> list) {
 		final List<Keyword> keywords = new ArrayList<>();
 		for (EObject eObject : list) {
@@ -213,7 +212,7 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 		}
 		return keywords;
 	}
-
+	
 	@Override
 	protected Function<IEObjectDescription, ICompletionProposal> getProposalFactory(String ruleName,
 			ContentAssistContext contentAssistContext) {
@@ -233,83 +232,83 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 						configurableProposal.setCursorPosition(configurableProposal.getCursorPosition() + 1);
 					}
 				}
-
+				
 				return proposal;
 			}
 		};
 	}
-
+	
 	@Override
 	public void completeElementReferenceExpression_Reference(EObject model, Assignment assignment,
 			ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
 		lookupCrossReference(((CrossReference) assignment.getTerminal()), context, acceptor);
 	}
-
+	
 	@Override
 	public void completeSimpleElementReferenceExpression_Reference(EObject model, Assignment assignment,
 			ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
 		lookupCrossReference(((CrossReference) assignment.getTerminal()), context, acceptor);
 	}
-
+	
 	@Override
 	public void completeTypeSpecifier_Type(EObject model, Assignment assignment, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
 		lookupCrossReference(((CrossReference) assignment.getTerminal()), context, acceptor);
 	}
-
+	
 	@Override
 	public void complete_BOOL(EObject model, RuleCall ruleCall, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
 		ICompletionProposalAcceptor priorityOptimizer = getCustomAcceptor(model, "boolean", acceptor);
-
+		
 		for (String s : new String[] { "true", "false", "yes", "no" }) {
 			ICompletionProposal proposal = createCompletionProposal(s, s + " - " + ruleCall.getRule().getName(), null,
 					context);
-
+			
 			priorityOptimizer.accept(proposal);
 		}
 	}
-
+	
 	@Override
 	public void completeImportScope_Imports(EObject model, Assignment assignment, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
-		PrefixMatcher newMatcher = new PrefixMatcher() {
-			@Override
-			public boolean isCandidateMatchingPrefix(String name, String prefix) {
-				String strippedName = name;
-				if (name.startsWith("^") && !prefix.startsWith("^")) {
-					strippedName = name.substring(1);
-				}
-				return context.getMatcher().isCandidateMatchingPrefix(strippedName, prefix);
-			}
-		};
-		ContentAssistContext myContext = context.copy().setMatcher(newMatcher).toContext();
-		StringProposalDelegate stringProposalDelegate = new StringProposalDelegate(acceptor, myContext);
+		StringProposalDelegate stringProposalDelegate = new StringProposalDelegate(acceptor, context);
 		Set<PackageImport> allImports = mapper.getAllImports(model.eResource());
 		for (PackageImport pkgImport : allImports) {
-			ICompletionProposal doCreateProposal = createCompletionProposal("\"" + pkgImport.getName() + "\"",
-					computePackageStyledString(pkgImport), getIncludeImage(pkgImport), myContext);
+			ICompletionProposal doCreateProposal = createCompletionProposal(
+					"\"" + pkgImport.getName() + "\"",
+					computePackageStyledString(pkgImport),
+					getIncludeImage(pkgImport),
+					pkgImport.getUri().isFile() ? 1 : -1,
+							context.getPrefix(), context);
 			stringProposalDelegate.accept(doCreateProposal);
 		}
 	}
-
+	
+	@Override
+	public ICompletionProposal createCompletionProposal(String proposal, StyledString displayString, Image image,
+			ContentAssistContext contentAssistContext) {
+		return createCompletionProposal(proposal, displayString, image, getPriorityHelper().getDefaultPriority(),
+				contentAssistContext.getPrefix(), contentAssistContext);
+	}
+	
 	protected Image getIncludeImage(PackageImport pkgImport) {
 		final ImageRegistry imageRegistry = STextActivator.getInstance().getImageRegistry();
 		return imageRegistry.get(ICONS_INCLUDE);
 	}
-
+	
 	protected StyledString computePackageStyledString(PackageImport pkgImport) {
 		StyledString firstPart = new StyledString(pkgImport.getName());
 		StyledString secondPart = getPackageImportStyleString(pkgImport.getUri());
 		return firstPart.append(secondPart);
 	}
-
+	
 	protected StyledString getPackageImportStyleString(URI uri) {
 		String headerFilePath = uri.isPlatform() ? uri.toPlatformString(true) : uri.toFileString();
 		StyledString secondPart = new StyledString(" - " + headerFilePath, new GreyoutStyler());
 		return secondPart;
 	}
-
+	
 	protected ICompletionProposalAcceptor getCustomAcceptor(EObject model, String typeName,
 			ICompletionProposalAcceptor acceptor) {
 		ICompletionProposalAcceptor priorityOptimizer = acceptor;
@@ -327,7 +326,7 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 		}
 		return priorityOptimizer;
 	}
-
+	
 	@Override
 	protected String getDisplayString(EObject element, String qualifiedNameAsString, String shortName) {
 		if (element instanceof Type) {
@@ -338,7 +337,7 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 					.toString(getQualifiedNameConverter().toQualifiedName(qualifiedNameAsString).skipFirst(1));
 			return super.getDisplayString(element, qualifiedNameAsString, shortName);
 		}
-
+		
 		if (element == null || element.eIsProxy()) {
 			return qualifiedNameAsString;
 		}
@@ -349,33 +348,33 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 		}
 		return super.getDisplayString(element, qualifiedNameAsString, shortName);
 	}
-
+	
 	@Override
 	public void complete_STRING(EObject model, RuleCall ruleCall, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
 		super.complete_STRING(model, ruleCall, context, getCustomAcceptor(model, "string", acceptor));
 	}
-
+	
 	@Override
 	public void complete_INT(EObject model, RuleCall ruleCall, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
 		super.complete_INT(model, ruleCall, context, getCustomAcceptor(model, "integer", acceptor));
 	}
-
+	
 	public void complete_XID(EObject model, RuleCall ruleCall, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
 		complete_ID(model, ruleCall, context, acceptor);
 	}
-
+	
 	@Override
 	public void complete_HEX(EObject model, RuleCall ruleCall, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
 		ICompletionProposalAcceptor priorityOptimizer = getCustomAcceptor(model, "integer", acceptor);
-
+		
 		String proposalText = "0x1";
 		ICompletionProposal proposal = createCompletionProposal(proposalText,
 				proposalText + " - " + ruleCall.getRule().getName(), null, context);
-
+		
 		if (proposal instanceof ConfigurableCompletionProposal) {
 			ConfigurableCompletionProposal configurable = (ConfigurableCompletionProposal) proposal;
 			configurable.setSelectionStart(configurable.getReplacementOffset() + 2);
@@ -383,21 +382,21 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 			configurable.setAutoInsertable(false);
 			configurable.setSimpleLinkedMode(context.getViewer(), '\t', ' ');
 		}
-
+		
 		priorityOptimizer.accept(proposal);
 	}
-
+	
 	@Override
 	public void complete_DOUBLE(EObject model, RuleCall ruleCall, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
 		ICompletionProposalAcceptor priorityOptimizer = getCustomAcceptor(model, "real", acceptor);
-
+		
 		String proposalText = "0.1";
 		ICompletionProposal proposal = createCompletionProposal(proposalText,
 				proposalText + " - " + ruleCall.getRule().getName(), null, context);
 		priorityOptimizer.accept(proposal);
 	}
-
+	
 	@Override
 	public void complete_IDWithKeywords(EObject model, RuleCall ruleCall, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
@@ -428,7 +427,7 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 		}
 		super.complete_ID(model, ruleCall, context, acceptor);
 	}
-
+	
 	private void createContentAssistForEntryAndExit(State state, boolean entry, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
 		for (Region region : state.getRegions()) {
@@ -451,33 +450,33 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 			}
 		}
 	}
-
+	
 	@Override
 	public void completeActiveStateReferenceExpression_Value(EObject model, Assignment assignment,
 			ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
 		lookupCrossReference(((CrossReference) assignment.getTerminal()), context, acceptor);
 	}
-
+	
 	private void alterPriority(ICompletionProposal proposal, int delta) {
 		if (proposal == null || !(proposal instanceof ConfigurableCompletionProposal))
 			return;
 		ConfigurableCompletionProposal castedProposal = (ConfigurableCompletionProposal) proposal;
 		castedProposal.setPriority(castedProposal.getPriority() + delta);
 	}
-
+	
 	/**
 	 * The acceptor delegate creates a Dummy EObject of type Keyword for the User
 	 * Help Hover integration
 	 *
 	 */
 	public class AcceptorDelegate implements ICompletionProposalAcceptor {
-
+		
 		private final ICompletionProposalAcceptor delegate;
-
+		
 		public AcceptorDelegate(ICompletionProposalAcceptor delegate) {
 			this.delegate = delegate;
 		}
-
+		
 		@Override
 		public void accept(ICompletionProposal proposal) {
 			if (proposal instanceof ConfigurableCompletionProposal) {
@@ -488,7 +487,7 @@ public class STextProposalProvider extends AbstractSTextProposalProvider {
 			}
 			delegate.accept(proposal);
 		}
-
+		
 		@Override
 		public boolean canAcceptMoreProposals() {
 			return delegate.canAcceptMoreProposals();


### PR DESCRIPTION
The function which created the import proposals just called the wrong method
to create the actual proposal which was an illegal shortcut.

`doCreateProposal` just returns a new Proposal obj, whereas
`createCompletionProposal` calls `isValidProposal` beforehand.