### PR TITLE
Use multibindings for operation mockups

### DIFF
--- a/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/DefaultExpressionInterpreter.xtend
+++ b/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/DefaultExpressionInterpreter.xtend
@@ -271,7 +271,7 @@ class DefaultExpressionInterpreter extends AbstractExpressionInterpreter impleme
 	def executeElementReferenceExpression(ElementReferenceExpression expression) {
 		val parameter = expression.expressions.map(it|execute)
 		if (expression.operationCall || expression.reference instanceof Operation) {
-			val operationDelegate = operationDelegates.findFirst[canExecute(null, expression.reference as Operation, parameter.toArray)]
+			val operationDelegate = operationDelegates?.findFirst[canExecute(null, expression.reference as Operation, parameter.toArray)]
 			if (operationDelegate !== null) {
 				return (expression.reference as Operation).execute(null, parameter.toArray, operationDelegate)
 			}
@@ -304,7 +304,7 @@ class DefaultExpressionInterpreter extends AbstractExpressionInterpreter impleme
 			val parameter = call.expressions.map(it|execute)
 			if (call.feature instanceof Operation) {
 				val Operation operation = call.feature as Operation
-				val operationDelegate = operationDelegates.findFirst[canExecute((call.owner as ElementReferenceExpression).reference as Declaration, operation, parameter.toArray)]
+				val operationDelegate = operationDelegates?.findFirst[canExecute((call.owner as ElementReferenceExpression).reference as Declaration, operation, parameter.toArray)]
 				if (operationDelegate !== null) {
 					return operation.execute((call.owner as ElementReferenceExpression).reference as Declaration, parameter, operationDelegate)
 				}

--- a/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/DefaultExpressionInterpreter.xtend
+++ b/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/DefaultExpressionInterpreter.xtend
@@ -52,6 +52,7 @@ import org.yakindu.sct.model.sruntime.ReferenceSlot
 import com.google.inject.Singleton
 import org.yakindu.base.expressions.expressions.PostFixUnaryExpression
 import java.util.Set
+import org.yakindu.base.types.Declaration
 
 /**
  * 
@@ -270,9 +271,9 @@ class DefaultExpressionInterpreter extends AbstractExpressionInterpreter impleme
 	def executeElementReferenceExpression(ElementReferenceExpression expression) {
 		val parameter = expression.expressions.map(it|execute)
 		if (expression.operationCall || expression.reference instanceof Operation) {
-			val operationDelegate = operationDelegates.findFirst[canExecute(expression.reference as Operation, parameter.toArray)]
+			val operationDelegate = operationDelegates.findFirst[canExecute(null, expression.reference as Operation, parameter.toArray)]
 			if (operationDelegate !== null) {
-				return (expression.reference as Operation).execute(parameter.toArray, operationDelegate)
+				return (expression.reference as Operation).execute(null, parameter.toArray, operationDelegate)
 			}
 		}
 		// for enumeration types return the literal value
@@ -303,9 +304,9 @@ class DefaultExpressionInterpreter extends AbstractExpressionInterpreter impleme
 			val parameter = call.expressions.map(it|execute)
 			if (call.feature instanceof Operation) {
 				val Operation operation = call.feature as Operation
-				val operationDelegate = operationDelegates.findFirst[canExecute(operation, parameter.toArray)]
+				val operationDelegate = operationDelegates.findFirst[canExecute((call.owner as ElementReferenceExpression).reference as Declaration, operation, parameter.toArray)]
 				if (operationDelegate !== null) {
-					return operation.execute(parameter, operationDelegate)
+					return operation.execute((call.owner as ElementReferenceExpression).reference as Declaration, parameter, operationDelegate)
 				}
 			}
 		} else if (call.feature instanceof Enumerator) {
@@ -334,8 +335,8 @@ class DefaultExpressionInterpreter extends AbstractExpressionInterpreter impleme
 		return evaluate(operator, result);
 	}
 
-	def execute(Operation it, List<Object> params, IOperationMockup operationDelegate) {
-		operationDelegate.execute(it, params)
+	def execute(Operation it, Declaration owner, List<Object> params, IOperationMockup operationDelegate) {
+		operationDelegate.execute(owner, it, params)
 	}
 
 }

--- a/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/IOperationMockup.java
+++ b/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/IOperationMockup.java
@@ -10,6 +10,7 @@
  */
 package org.yakindu.base.expressions.interpreter;
 
+import org.yakindu.base.types.Declaration;
 import org.yakindu.base.types.Operation;
 
 /**
@@ -26,14 +27,14 @@ public interface IOperationMockup {
 	 * @return true if the implementation provides a mockup for the given
 	 *         definition, false otherwise
 	 */
-	public boolean canExecute(Operation definition, Object[] parameter);
+	public boolean canExecute(Declaration owner, Operation definition, Object[] parameter);
 
 	/**
 	 * Called when the operation is executed
 	 * 
 	 * @return the operations return value, maybe null
 	 */
-	public Object execute(Operation definition, Object[] parameter);
+	public Object execute(Declaration owner, Operation definition, Object[] parameter);
 	
 	/**
 	 * @author Johannes Dicks - Initial contribution and API
@@ -41,12 +42,12 @@ public interface IOperationMockup {
 	public static final class NullOperationMock implements IOperationMockup{
 
 		@Override
-		public boolean canExecute(Operation definition, Object[] parameter) {
+		public boolean canExecute(Declaration owner, Operation definition, Object[] parameter) {
 			return false;
 		}
 
 		@Override
-		public Object execute(Operation definition, Object[] parameter) {
+		public Object execute(Declaration owner, Operation definition, Object[] parameter) {
 			return null;
 		}
 	}

--- a/plugins/org.yakindu.sct.domain.generic.simulation/META-INF/MANIFEST.MF
+++ b/plugins/org.yakindu.sct.domain.generic.simulation/META-INF/MANIFEST.MF
@@ -11,4 +11,5 @@ Require-Bundle: org.yakindu.sct.simulation.core,
  org.yakindu.sct.simulation.core.sexec,
  org.yakindu.sct.model.sexec,
  org.yakindu.base.expressions.interpreter
+Import-Package: com.google.inject.multibindings;version="1.3.0"
 Export-Package: org.yakindu.sct.domain.generic.simulation

--- a/plugins/org.yakindu.sct.domain.generic.simulation/src/org/yakindu/sct/domain/generic/simulation/GenericSimulationModule.java
+++ b/plugins/org.yakindu.sct.domain.generic.simulation/src/org/yakindu/sct/domain/generic/simulation/GenericSimulationModule.java
@@ -36,6 +36,7 @@ import org.yakindu.sct.simulation.core.sexec.interpreter.JavaOperationMockup;
 import org.yakindu.sct.simulation.core.sexec.interpreter.StextExpressionInterpreter;
 
 import com.google.inject.Binder;
+import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 
 /**
@@ -50,6 +51,13 @@ public class GenericSimulationModule extends AbstractGenericModule {
 		super.configure(binder);
 		binder.bind(Boolean.class).annotatedWith(Names.named(IModelSequencer.ADD_TRACES)).toInstance(Boolean.TRUE);
 		binder.bind(ITypeSystem.class).toInstance(getTypeSystem());
+		
+		bindOperationMockups(binder);
+	}
+
+	protected void bindOperationMockups(Binder binder) {
+		Multibinder<IOperationMockup> mockupBinder = Multibinder.newSetBinder(binder, IOperationMockup.class);
+		mockupBinder.addBinding().to(JavaOperationMockup.class);
 	}
 
 	protected ITypeSystem getTypeSystem() {
@@ -66,10 +74,6 @@ public class GenericSimulationModule extends AbstractGenericModule {
 
 	public Class<? extends IModelSequencer> bindIModelSequencer() {
 		return ModelSequencer.class;
-	}
-
-	public Class<? extends IOperationMockup> bindIOperationMockup() {
-		return JavaOperationMockup.class;
 	}
 
 	public Class<? extends ExecutionContext> bindExecutionContext() {

--- a/plugins/org.yakindu.sct.simulation.core.sexec/src/org/yakindu/sct/simulation/core/sexec/interpreter/DefaultOperationMockup.java
+++ b/plugins/org.yakindu.sct.simulation.core.sexec/src/org/yakindu/sct/simulation/core/sexec/interpreter/DefaultOperationMockup.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.yakindu.base.expressions.expressions.IntLiteral;
 import org.yakindu.base.expressions.interpreter.IOperationMockup;
+import org.yakindu.base.types.Declaration;
 import org.yakindu.base.types.Operation;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -38,12 +39,12 @@ public class DefaultOperationMockup implements IOperationMockup {
 	protected Multimap<String, List<Object>> verifyCalls = ArrayListMultimap.create();
 
 	@Override
-	public boolean canExecute(Operation definition, Object[] parameter) {
+	public boolean canExecute(Declaration owner, Operation definition, Object[] parameter) {
 		return true;
 	}
 
 	@Override
-	public Object execute(Operation definition, Object[] parameter) {
+	public Object execute(Declaration owner, Operation definition, Object[] parameter) {
 		verifyCalls.put(definition.getName(), asList(parameter));
 		return mockReturn.get(definition.getName(), asList(parameter));
 	}

--- a/plugins/org.yakindu.sct.simulation.core.sexec/src/org/yakindu/sct/simulation/core/sexec/interpreter/JavaOperationMockup.java
+++ b/plugins/org.yakindu.sct.simulation.core.sexec/src/org/yakindu/sct/simulation/core/sexec/interpreter/JavaOperationMockup.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.yakindu.base.expressions.interpreter.IExecutionSlotResolver;
 import org.yakindu.base.expressions.interpreter.IOperationMockup;
+import org.yakindu.base.types.Declaration;
 import org.yakindu.base.types.Operation;
 import org.yakindu.sct.commons.WorkspaceClassLoaderFactory;
 import org.yakindu.sct.model.stext.stext.InterfaceScope;
@@ -63,7 +64,7 @@ public class JavaOperationMockup implements IOperationMockup {
 	}
 
 	@Override
-	public boolean canExecute(Operation definition, Object[] parameter) {
+	public boolean canExecute(Declaration owner, Operation definition, Object[] parameter) {
 		for (Object callback : callbacks) {
 			Class<?> current = callback.getClass();
 			while (current != Object.class) {
@@ -80,7 +81,7 @@ public class JavaOperationMockup implements IOperationMockup {
 		return false;
 	}
 
-	public Object execute(Operation definition, Object[] parameter) {
+	public Object execute(Declaration owner, Operation definition, Object[] parameter) {
 		List<Object> targets = callbacks;
 		if (definition.eContainer() instanceof InterfaceScope) {
 			String className = ((InterfaceScope) definition.eContainer()).getName();

--- a/plugins/org.yakindu.sct.simulation.core.sexec/src/org/yakindu/sct/simulation/core/sexec/launch/SexecLaunchConfigurationDelegate.java
+++ b/plugins/org.yakindu.sct.simulation.core.sexec/src/org/yakindu/sct/simulation/core/sexec/launch/SexecLaunchConfigurationDelegate.java
@@ -10,6 +10,8 @@
  */
 package org.yakindu.sct.simulation.core.sexec.launch;
 
+import java.util.Set;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -40,6 +42,9 @@ public class SexecLaunchConfigurationDelegate extends AbstractSCTLaunchConfigura
 
 	@Inject
 	private ISimulationEngineFactory factory;
+	
+	@Inject
+	private Set<IOperationMockup> mockups;
 
 	@Override
 	protected ISimulationEngine createExecutionContainer(final ILaunch launch, Statechart statechart) {
@@ -48,12 +53,14 @@ public class SexecLaunchConfigurationDelegate extends AbstractSCTLaunchConfigura
 			Injector injector = getInjector(statechart, launch);
 			IFile file = WorkspaceSynchronizer.getFile(statechart.eResource());
 			injector.injectMembers(this);
-			IOperationMockup mockup = injector.getInstance(IOperationMockup.class);
-			if (mockup instanceof JavaOperationMockup) {
-				IProject project = file.getProject();
-				String classes = launch.getLaunchConfiguration().getAttribute(ISCTLaunchParameters.OPERATION_CLASS, "");
-				String[] split = classes.split(",");
-				((JavaOperationMockup) mockup).initOperationCallbacks(project, split);
+			
+			for (IOperationMockup mockup : mockups) {
+				if (mockup instanceof JavaOperationMockup) {
+					IProject project = file.getProject();
+					String classes = launch.getLaunchConfiguration().getAttribute(ISCTLaunchParameters.OPERATION_CLASS, "");
+					String[] split = classes.split(",");
+					((JavaOperationMockup) mockup).initOperationCallbacks(project, split);
+				}
 			}
 			return factory.createExecutionContainer(statechart, launch);
 		} catch (CoreException e) {

--- a/test-plugins/org.yakindu.sct.simulation.core.sexec.test/src/org/yakindu/sct/model/sexec/interpreter/test/util/InterpreterTestModule.java
+++ b/test-plugins/org.yakindu.sct.simulation.core.sexec.test/src/org/yakindu/sct/model/sexec/interpreter/test/util/InterpreterTestModule.java
@@ -14,15 +14,19 @@ import org.yakindu.base.expressions.interpreter.IOperationMockup;
 import org.yakindu.sct.domain.generic.simulation.GenericSimulationModule;
 import org.yakindu.sct.simulation.core.sexec.interpreter.DefaultOperationMockup;
 
+import com.google.inject.Binder;
+import com.google.inject.multibindings.Multibinder;
+
 /**
  * 
  * @author jonathan thoene - Initial contribution and API
  * 
  */
-public class InterpreterTestModule extends GenericSimulationModule{
-	
+public class InterpreterTestModule extends GenericSimulationModule {
+
 	@Override
-	public Class<? extends IOperationMockup> bindIOperationMockup() {
-		return DefaultOperationMockup.class;
+	protected void bindOperationMockups(Binder binder) {
+		Multibinder<IOperationMockup> mockupBinder = Multibinder.newSetBinder(binder, IOperationMockup.class);
+		mockupBinder.addBinding().to(DefaultOperationMockup.class);
 	}
 }


### PR DESCRIPTION
This allows to combine different mockups. The first one that is responsible for an operation will be executed.