### PR TITLE
Avoid array out of bounds exception

### DIFF
--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/definitionsection/StatechartDefinitionSection.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/definitionsection/StatechartDefinitionSection.java
@@ -548,8 +548,10 @@ public class StatechartDefinitionSection extends Composite implements IPersistab
 
 	protected void setMementoProperties(IMemento memento) {
 		String sectionProperty = getSectionProperty(getContextObject());
-		memento.putInteger(sectionProperty + MEM_FIRST_WEIGHT, previousWidths[0]);
-		memento.putInteger(sectionProperty + MEM_SECOND_WEIGHT, previousWidths[1]);
+		if (previousWidths.length >= 2) {
+			memento.putInteger(sectionProperty + MEM_FIRST_WEIGHT, previousWidths[0]);
+			memento.putInteger(sectionProperty + MEM_SECOND_WEIGHT, previousWidths[1]);
+		}
 		memento.putBoolean(sectionProperty + MEM_EXPANDED, sectionExpanded);
 	}
 


### PR DESCRIPTION
In some cases an array out of bounds exception is thrown. It is not clear how that is possible as previousWidths seems to be always initialized with two values. Might be some race condition. Observed on macOS.