### PR TITLE
Avoid cyclic updating of name label (#2373)

### DIFF
--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/definitionsection/StatechartDefinitionSection.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/definitionsection/StatechartDefinitionSection.java
@@ -816,7 +816,11 @@ public class StatechartDefinitionSection extends Composite implements IPersistab
 		public void notifyChanged(Notification notification) {
 			if (Notification.SET == notification.getEventType()) {
 				if (BasePackage.Literals.NAMED_ELEMENT__NAME.equals(notification.getFeature())) {
-					nameLabel.setText(notification.getNewStringValue());
+					String newText = notification.getNewStringValue();
+					String oldText = nameLabel.getText();
+					if (!oldText.equals(newText)) {
+						nameLabel.setText(newText);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Changing the name label in UI invokes a notification which in return changes the name label. Although this second change does not invoke another notification, it resets the cursor to the beginning of the text field which makes the text field unusable.

fixes #2373 