### PR TITLE
Don't use strcmp for C++

### DIFF
--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/CppExpressionsGenerator.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/CppExpressionsGenerator.xtend
@@ -14,18 +14,20 @@ package org.yakindu.sct.generator.cpp
 import com.google.inject.Inject
 import org.yakindu.base.expressions.expressions.BoolLiteral
 import org.yakindu.base.expressions.expressions.ElementReferenceExpression
+import org.yakindu.base.expressions.expressions.Expression
 import org.yakindu.base.expressions.expressions.FeatureCall
+import org.yakindu.base.expressions.expressions.LogicalNotExpression
+import org.yakindu.base.expressions.expressions.LogicalRelationExpression
 import org.yakindu.base.expressions.expressions.StringLiteral
+import org.yakindu.base.types.typesystem.GenericTypeSystem
 import org.yakindu.base.types.typesystem.ITypeSystem
 import org.yakindu.sct.generator.c.CExpressionsGenerator
+import org.yakindu.sct.model.sexec.Method
 import org.yakindu.sct.model.sexec.extensions.SExecExtensions
 import org.yakindu.sct.model.sexec.naming.INamingService
 import org.yakindu.sct.model.stext.stext.ActiveStateReferenceExpression
 import org.yakindu.sct.model.stext.stext.EventRaisingExpression
 import org.yakindu.sct.model.stext.stext.OperationDefinition
-import org.yakindu.base.expressions.expressions.Expression
-import org.yakindu.base.expressions.expressions.LogicalNotExpression
-import org.yakindu.sct.model.sexec.Method
 
 import static org.yakindu.sct.generator.c.CGeneratorConstants.*
 
@@ -68,6 +70,10 @@ class CppExpressionsGenerator extends CExpressionsGenerator {
 	/** Don't use bool_false for C++ code */
 	override dispatch CharSequence sc_boolean_code(LogicalNotExpression it) {code}
 	
+	override dispatch CharSequence code(LogicalRelationExpression it) '''
+	«IF isSame(leftOperand.infer.type, getType(GenericTypeSystem.STRING))»
+		«leftOperand.code» == «rightOperand.code»
+	«ELSE»(«leftOperand.code») «operator.literal» («rightOperand.code»)«ENDIF»'''
 	
 
 }

--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/CppExpressionsGenerator.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/CppExpressionsGenerator.xtend
@@ -72,7 +72,7 @@ class CppExpressionsGenerator extends CExpressionsGenerator {
 	
 	override dispatch CharSequence code(LogicalRelationExpression it) '''
 	«IF isSame(leftOperand.infer.type, getType(GenericTypeSystem.STRING))»
-		«leftOperand.code» == «rightOperand.code»
+		(strcmp(«leftOperand.code», «rightOperand.code») «operator.literal» 0)
 	«ELSE»(«leftOperand.code») «operator.literal» («rightOperand.code»)«ENDIF»'''
 	
 


### PR DESCRIPTION
Otherwise CExpressionsGenerator with strcmp is used.

Needed for https://github.com/Yakindu/sctpro/pull/1787