### PR TITLE
NPE in DefaultResourceChangeToIssueProcessor

### DIFF
--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/validation/DefaultResourceChangeToIssueProcessor.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/validation/DefaultResourceChangeToIssueProcessor.java
@@ -47,6 +47,9 @@ public class DefaultResourceChangeToIssueProcessor implements IResourceChangeToI
 	public ResourceDeltaToIssueResult process(IResourceChangeEvent event, Resource connectedResource,
 			Multimap<String, SCTIssue> visibleIssues) {
 		final IFile file = WorkspaceSynchronizer.getFile(connectedResource);
+		if (file == null) {
+		    return null;
+		}
 		final IResourceDelta deltaForFile = getDeltaForFile(event, file);
 		if (deltaForFile == null) {
 			return null;


### PR DESCRIPTION
During SWTBot tests we have seen this exception. It looks like a race
condition in DefaultValidationIssueStore, where that store is being
disconnected (line 160) while another ResourceChangeEvent is still being
processed.

Since I assume that this race condition does not occur under normal
manual usage (but only in fast UI testing) it seems reasonable to just
ignore that (last) resource change event using an additional guard.

java.lang.NullPointerException: null
	at org.yakindu.sct.ui.editor.validation.DefaultResourceChangeToIssueProcessor.getDeltaForFile(DefaultResourceChangeToIssueProcessor.java:65)
~[na:na]
	at org.yakindu.sct.ui.editor.validation.DefaultResourceChangeToIssueProcessor.process(DefaultResourceChangeToIssueProcessor.java:50)
~[na:na]
	at org.yakindu.sct.ui.editor.validation.DefaultValidationIssueStore.resourceChanged(DefaultValidationIssueStore.java:250)
~[na:na]
	at org.eclipse.core.internal.events.NotificationManager$1.run(NotificationManager.java:299)
~[na:na]