### PR TITLE
Add -I option to makefile compile targets

### DIFF
--- a/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/CompileGTestCommand.java
+++ b/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/CompileGTestCommand.java
@@ -155,6 +155,11 @@ public class CompileGTestCommand {
 	protected String compileCommand(String sourceFile, String objectFile) {
 		StringBuilder command = new StringBuilder();
 		command.append(compiler).append(" -c").append(" -o ").append(objectFile).append(" -O1 ").append(sourceFile);
+		if (dir != null)
+			command.append(" -I" + dir + "/include");
+		for (String include : includes) {
+			command.append(" -I" + include);
+		}
 		return command.toString();
 	}
 


### PR DESCRIPTION
`-I` tells gcc where to look for header files, and was forgotten in the previous
version.

Fix Yakindu/sctpro#1824