### PR TITLE
Replace string with function call for NullState

### DIFF
--- a/plugins/org.yakindu.sct.generator.java/src/org/yakindu/sct/generator/java/FlowCode.xtend
+++ b/plugins/org.yakindu.sct.generator.java/src/org/yakindu/sct/generator/java/FlowCode.xtend
@@ -130,7 +130,7 @@ class FlowCode {
 	
 	def dispatch CharSequence code(HistoryEntry it) '''
 		«stepComment»
-		if (historyVector[«region.historyVector.offset»] != State.$NullState$) {
+		if (historyVector[«region.historyVector.offset»] != State.«getNullStateName()» {
 			«historyStep.code»
 		} «IF initialStep !== null»else {
 			«initialStep.code»


### PR DESCRIPTION
The code generator uses getNullStateName for the NullState in all other cases.