### PR TITLE
make StatechartSpecification an AnnotatableElement

### DIFF
--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/impl/StatechartImpl.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/impl/StatechartImpl.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * Contributors:
  * committers of YAKINDU - initial API and implementation
- * 
+ *
  */
 package org.yakindu.sct.model.sgraph.impl;
 
@@ -61,13 +61,13 @@ import org.yakindu.sct.model.sgraph.Statechart;
  * @generated
  */
 public class StatechartImpl extends SpecificationElementImpl implements
-		Statechart {
+Statechart {
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	public static final String copyright = "Copyright (c) 2011 committers of YAKINDU and others.\r\nAll rights reserved. This program and the accompanying materials\r\nare made available under the terms of the Eclipse Public License v1.0\r\nwhich accompanies this distribution, and is available at\r\nhttp://www.eclipse.org/legal/epl-v10.html\r\nContributors:\r\ncommitters of YAKINDU - initial API and implementation\r\n";
-
+	
 	/**
 	 * The cached value of the '{@link #getScopes() <em>Scopes</em>}' containment reference list.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -76,7 +76,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	 * @ordered
 	 */
 	protected EList<Scope> scopes;
-
+	
 	/**
 	 * The default value of the '{@link #getNamespace() <em>Namespace</em>}' attribute.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -85,7 +85,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	 * @ordered
 	 */
 	protected static final String NAMESPACE_EDEFAULT = null;
-
+	
 	/**
 	 * The cached value of the '{@link #getNamespace() <em>Namespace</em>}' attribute.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -94,7 +94,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	 * @ordered
 	 */
 	protected String namespace = NAMESPACE_EDEFAULT;
-
+	
 	/**
 	 * The cached value of the '{@link #getRegions() <em>Regions</em>}' containment reference list.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -103,7 +103,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	 * @ordered
 	 */
 	protected EList<Region> regions;
-
+	
 	/**
 	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -112,7 +112,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	 * @ordered
 	 */
 	protected static final String NAME_EDEFAULT = null;
-
+	
 	/**
 	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -121,7 +121,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	 * @ordered
 	 */
 	protected String name = NAME_EDEFAULT;
-
+	
 	/**
 	 * The default value of the '{@link #getDocumentation() <em>Documentation</em>}' attribute.
 	 * <!-- begin-user-doc --> <!--
@@ -131,7 +131,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	 * @ordered
 	 */
 	protected static final String DOCUMENTATION_EDEFAULT = "";
-
+	
 	/**
 	 * The cached value of the '{@link #getDocumentation() <em>Documentation</em>}' attribute.
 	 * <!-- begin-user-doc --> <!--
@@ -141,7 +141,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	 * @ordered
 	 */
 	protected String documentation = DOCUMENTATION_EDEFAULT;
-
+	
 	/**
 	 * The default value of the '{@link #getDomainID() <em>Domain ID</em>}' attribute.
 	 * <!-- begin-user-doc -->
@@ -151,7 +151,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	 * @ordered
 	 */
 	protected static final String DOMAIN_ID_EDEFAULT = "org.yakindu.domain.default";
-
+	
 	/**
 	 * The cached value of the '{@link #getDomainID() <em>Domain ID</em>}' attribute.
 	 * <!-- begin-user-doc -->
@@ -161,7 +161,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	 * @ordered
 	 */
 	protected String domainID = DOMAIN_ID_EDEFAULT;
-
+	
 	/**
 	 * The cached value of the '{@link #getAnnotations() <em>Annotations</em>}' containment reference list.
 	 * <!-- begin-user-doc -->
@@ -171,7 +171,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	 * @ordered
 	 */
 	protected EList<Annotation> annotations;
-
+	
 	/**
 	 * The cached value of the '{@link #getAnnotationInfo() <em>Annotation Info</em>}' containment reference.
 	 * <!-- begin-user-doc -->
@@ -181,7 +181,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	 * @ordered
 	 */
 	protected AnnotatableElement annotationInfo;
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
@@ -189,7 +189,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	protected StatechartImpl() {
 		super();
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
@@ -198,155 +198,168 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	protected EClass eStaticClass() {
 		return SGraphPackage.Literals.STATECHART;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated NOT
 	 */
 	public EList<Reaction> getReactions() {
-		EList<Reaction> result = new BasicInternalEList<Reaction>(
+		EList<Reaction> result = new BasicInternalEList<>(
 				Reaction.class);
 		result.addAll(getLocalReactions());
 		return result;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated NOT
 	 */
+	@Override
 	public EList<Reaction> getLocalReactions() {
-		EList<Reaction> result = new BasicEList<Reaction>();
+		EList<Reaction> result = new BasicEList<>();
 		EList<Scope> scopes = getScopes();
 		for (Scope scope : scopes) {
-				result.addAll(scope.getReactions());
+			result.addAll(scope.getReactions());
 		}
-		return new EcoreEList.UnmodifiableEList<Reaction>(this,
+		return new EcoreEList.UnmodifiableEList<>(this,
 				SGraphPackage.Literals.REACTIVE_ELEMENT__LOCAL_REACTIONS, result.size(), result.toArray());
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<Scope> getScopes() {
 		if (scopes == null) {
-			scopes = new EObjectContainmentEList.Resolving<Scope>(Scope.class, this, SGraphPackage.STATECHART__SCOPES);
+			scopes = new EObjectContainmentEList.Resolving<>(Scope.class, this, SGraphPackage.STATECHART__SCOPES);
 		}
 		return scopes;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getNamespace() {
 		return namespace;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setNamespace(String newNamespace) {
 		String oldNamespace = namespace;
 		namespace = newNamespace;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, SGraphPackage.STATECHART__NAMESPACE, oldNamespace, namespace));
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<Region> getRegions() {
 		if (regions == null) {
-			regions = new EObjectContainmentWithInverseEList.Resolving<Region>(Region.class, this, SGraphPackage.STATECHART__REGIONS, SGraphPackage.REGION__COMPOSITE);
+			regions = new EObjectContainmentWithInverseEList.Resolving<>(Region.class, this, SGraphPackage.STATECHART__REGIONS, SGraphPackage.REGION__COMPOSITE);
 		}
 		return regions;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setName(String newName) {
 		String oldName = name;
 		name = newName;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, SGraphPackage.STATECHART__NAME, oldName, name));
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getDocumentation() {
 		return documentation;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setDocumentation(String newDocumentation) {
 		String oldDocumentation = documentation;
 		documentation = newDocumentation;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, SGraphPackage.STATECHART__DOCUMENTATION, oldDocumentation, documentation));
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getDomainID() {
 		return domainID;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setDomainID(String newDomainID) {
 		String oldDomainID = domainID;
 		domainID = newDomainID;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, SGraphPackage.STATECHART__DOMAIN_ID, oldDomainID, domainID));
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<Annotation> getAnnotations() {
 		if (annotations == null) {
-			annotations = new EObjectContainmentEList<Annotation>(Annotation.class, this, SGraphPackage.STATECHART__ANNOTATIONS);
+			annotations = new EObjectContainmentEList<>(Annotation.class, this, SGraphPackage.STATECHART__ANNOTATIONS);
 		}
 		return annotations;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public AnnotatableElement getAnnotationInfo() {
 		return annotationInfo;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -361,12 +374,13 @@ public class StatechartImpl extends SpecificationElementImpl implements
 		}
 		return msgs;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setAnnotationInfo(AnnotatableElement newAnnotationInfo) {
 		if (newAnnotationInfo != annotationInfo) {
 			NotificationChain msgs = null;
@@ -380,13 +394,14 @@ public class StatechartImpl extends SpecificationElementImpl implements
 		else if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, SGraphPackage.STATECHART__ANNOTATION_INFO, newAnnotationInfo, newAnnotationInfo));
 	}
-
+	
 	/**
-	 * <!-- begin-user-doc --> 
+	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated NOT
 	 */
+	@Override
 	public Annotation getAnnotationOfType(final String typeName) {
 		EList<Annotation> annotations = getAnnotations();
 		for (Annotation annotation : annotations) {
@@ -396,7 +411,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 		}
 		return null;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
@@ -411,7 +426,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
@@ -431,7 +446,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 		}
 		return super.eInverseRemove(otherEnd, featureID, msgs);
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
@@ -460,7 +475,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
@@ -499,7 +514,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 		}
 		super.eSet(featureID, newValue);
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
@@ -534,7 +549,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 		}
 		super.eUnset(featureID);
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
@@ -563,7 +578,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 		}
 		return super.eIsSet(featureID);
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
@@ -616,7 +631,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 		}
 		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
@@ -669,7 +684,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 		}
 		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
@@ -677,7 +692,7 @@ public class StatechartImpl extends SpecificationElementImpl implements
 	@Override
 	public String toString() {
 		if (eIsProxy()) return super.toString();
-
+		
 		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (namespace: ");
 		result.append(namespace);
@@ -690,5 +705,5 @@ public class StatechartImpl extends SpecificationElementImpl implements
 		result.append(')');
 		return result.toString();
 	}
-
+	
 } // StatechartImpl

--- a/plugins/org.yakindu.sct.model.stext.edit/src/org/yakindu/sct/model/stext/stext/provider/EventDefinitionItemProvider.java
+++ b/plugins/org.yakindu.sct.model.stext.edit/src/org/yakindu/sct/model/stext/stext/provider/EventDefinitionItemProvider.java
@@ -18,7 +18,11 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
 import org.yakindu.base.types.Event;
+import org.yakindu.base.types.TypesPackage;
 import org.yakindu.base.types.provider.EventItemProvider;
+import org.yakindu.sct.model.sgraph.SGraphFactory;
+import org.yakindu.sct.model.stext.stext.EventDefinition;
+import org.yakindu.sct.model.stext.stext.StextFactory;
 
 /**
  * This is the item provider adapter for a
@@ -100,6 +104,41 @@ public class EventDefinitionItemProvider extends EventItemProvider {
 	@Override
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createStatechartSpecification()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createEventDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createVariableDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createOperationDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createTypeAliasDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 SGraphFactory.eINSTANCE.createStatechart()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 SGraphFactory.eINSTANCE.createImportDeclaration()));
 	}
 
 	/**

--- a/plugins/org.yakindu.sct.model.stext.edit/src/org/yakindu/sct/model/stext/stext/provider/OperationDefinitionItemProvider.java
+++ b/plugins/org.yakindu.sct.model.stext.edit/src/org/yakindu/sct/model/stext/stext/provider/OperationDefinitionItemProvider.java
@@ -18,7 +18,11 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
+import org.yakindu.base.types.TypesPackage;
 import org.yakindu.base.types.provider.OperationItemProvider;
+import org.yakindu.sct.model.sgraph.SGraphFactory;
+import org.yakindu.sct.model.stext.stext.OperationDefinition;
+import org.yakindu.sct.model.stext.stext.StextFactory;
 
 /**
  * This is the item provider adapter for a {@link org.yakindu.sct.model.stext.stext.OperationDefinition} object.
@@ -103,9 +107,68 @@ public class OperationDefinitionItemProvider extends OperationItemProvider
   protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object)
   {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createStatechartSpecification()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createEventDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createVariableDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createOperationDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createTypeAliasDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 SGraphFactory.eINSTANCE.createStatechart()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 SGraphFactory.eINSTANCE.createImportDeclaration()));
 	}
 
   /**
+	 * This returns the label text for {@link org.eclipse.emf.edit.command.CreateChildCommand}.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String getCreateChildText(Object owner, Object feature, Object child, Collection<?> selection) {
+		Object childFeature = feature;
+		Object childObject = child;
+
+		boolean qualify =
+			childFeature == TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO ||
+			childFeature == TypesPackage.Literals.OPERATION__PARAMETERS ||
+			childFeature == TypesPackage.Literals.GENERIC_ELEMENT__TYPE_PARAMETERS;
+
+		if (qualify) {
+			return getString
+				("_UI_CreateChild_text2",
+				 new Object[] { getTypeText(childObject), getFeatureText(childFeature), getTypeText(owner) });
+		}
+		return super.getCreateChildText(owner, feature, child, selection);
+	}
+
+		/**
 	 * Return the resource locator for this item provider's resources.
 	 * <!-- begin-user-doc -->
    * <!-- end-user-doc -->

--- a/plugins/org.yakindu.sct.model.stext.edit/src/org/yakindu/sct/model/stext/stext/provider/StatechartSpecificationItemProvider.java
+++ b/plugins/org.yakindu.sct.model.stext.edit/src/org/yakindu/sct/model/stext/stext/provider/StatechartSpecificationItemProvider.java
@@ -21,6 +21,8 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
 import org.eclipse.emf.edit.provider.ViewerNotification;
 import org.yakindu.base.types.TypesFactory;
+import org.yakindu.base.types.TypesPackage;
+import org.yakindu.sct.model.sgraph.SGraphFactory;
 import org.yakindu.sct.model.sgraph.SGraphPackage;
 import org.yakindu.sct.model.sgraph.provider.ScopedElementItemProvider;
 import org.yakindu.sct.model.stext.stext.StatechartSpecification;
@@ -74,7 +76,8 @@ public class StatechartSpecificationItemProvider extends ScopedElementItemProvid
 	public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {
 		if (childrenFeatures == null) {
 			super.getChildrenFeatures(object);
-			childrenFeatures.add(StextPackage.Literals.STATECHART_SPECIFICATION__ANNOTATIONS);
+			childrenFeatures.add(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATIONS);
+			childrenFeatures.add(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO);
 		}
 		return childrenFeatures;
 	}
@@ -134,6 +137,7 @@ public class StatechartSpecificationItemProvider extends ScopedElementItemProvid
 
 		switch (notification.getFeatureID(StatechartSpecification.class)) {
 			case StextPackage.STATECHART_SPECIFICATION__ANNOTATIONS:
+			case StextPackage.STATECHART_SPECIFICATION__ANNOTATION_INFO:
 				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
 				return;
 		}
@@ -179,8 +183,118 @@ public class StatechartSpecificationItemProvider extends ScopedElementItemProvid
 
 		newChildDescriptors.add
 			(createChildParameter
-				(StextPackage.Literals.STATECHART_SPECIFICATION__ANNOTATIONS,
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATIONS,
 				 TypesFactory.eINSTANCE.createAnnotation()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createStatechartSpecification()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createEventDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createVariableDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createOperationDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createTypeAliasDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createPackageMember()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createPackage()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createType()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createOperation()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createProperty()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createParameter()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createEvent()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createComplexType()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createEnumerationType()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createPrimitiveType()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createEnumerator()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createTypeParameter()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createTypeAlias()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createAnnotatableElement()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 TypesFactory.eINSTANCE.createAnnotationType()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 SGraphFactory.eINSTANCE.createStatechart()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 SGraphFactory.eINSTANCE.createImportDeclaration()));
 	}
 
   /**

--- a/plugins/org.yakindu.sct.model.stext.edit/src/org/yakindu/sct/model/stext/stext/provider/TypeAliasDefinitionItemProvider.java
+++ b/plugins/org.yakindu.sct.model.stext.edit/src/org/yakindu/sct/model/stext/stext/provider/TypeAliasDefinitionItemProvider.java
@@ -23,6 +23,8 @@ import org.eclipse.emf.edit.provider.ViewerNotification;
 import org.yakindu.base.types.TypeAlias;
 import org.yakindu.base.types.TypesPackage;
 import org.yakindu.base.types.provider.TypeAliasItemProvider;
+import org.yakindu.sct.model.sgraph.SGraphFactory;
+import org.yakindu.sct.model.stext.stext.StextFactory;
 import org.yakindu.sct.model.stext.stext.StextPackage;
 import org.yakindu.sct.model.stext.stext.TypeAliasDefinition;
 
@@ -147,6 +149,41 @@ public class TypeAliasDefinitionItemProvider extends TypeAliasItemProvider {
 	@Override
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createStatechartSpecification()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createEventDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createVariableDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createOperationDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createTypeAliasDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 SGraphFactory.eINSTANCE.createStatechart()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 SGraphFactory.eINSTANCE.createImportDeclaration()));
 	}
 
 	/**

--- a/plugins/org.yakindu.sct.model.stext.edit/src/org/yakindu/sct/model/stext/stext/provider/VariableDefinitionItemProvider.java
+++ b/plugins/org.yakindu.sct.model.stext.edit/src/org/yakindu/sct/model/stext/stext/provider/VariableDefinitionItemProvider.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
 import org.yakindu.base.expressions.expressions.ExpressionsFactory;
 import org.yakindu.base.types.TypesPackage;
 import org.yakindu.base.types.provider.PropertyItemProvider;
+import org.yakindu.sct.model.sgraph.SGraphFactory;
 import org.yakindu.sct.model.stext.stext.StextFactory;
 import org.yakindu.sct.model.stext.stext.VariableDefinition;
 
@@ -108,6 +109,41 @@ public class VariableDefinitionItemProvider extends PropertyItemProvider {
 	@Override
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createStatechartSpecification()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createEventDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createVariableDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createOperationDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 StextFactory.eINSTANCE.createTypeAliasDefinition()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 SGraphFactory.eINSTANCE.createStatechart()));
+
+		newChildDescriptors.add
+			(createChildParameter
+				(TypesPackage.Literals.ANNOTATABLE_ELEMENT__ANNOTATION_INFO,
+				 SGraphFactory.eINSTANCE.createImportDeclaration()));
 
 		newChildDescriptors.add
 			(createChildParameter

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/StatechartSpecification.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/StatechartSpecification.java
@@ -3,6 +3,7 @@
 package org.yakindu.sct.model.stext.stext;
 
 import org.eclipse.emf.common.util.EList;
+import org.yakindu.base.types.AnnotatableElement;
 import org.yakindu.base.types.Annotation;
 import org.yakindu.sct.model.sgraph.ScopedElement;
 
@@ -11,32 +12,10 @@ import org.yakindu.sct.model.sgraph.ScopedElement;
  * A representation of the model object '<em><b>Statechart Specification</b></em>'.
  * <!-- end-user-doc -->
  *
- * <p>
- * The following features are supported:
- * </p>
- * <ul>
- *   <li>{@link org.yakindu.sct.model.stext.stext.StatechartSpecification#getAnnotations <em>Annotations</em>}</li>
- * </ul>
  *
  * @see org.yakindu.sct.model.stext.stext.StextPackage#getStatechartSpecification()
  * @model
  * @generated
  */
-public interface StatechartSpecification extends ScopedElement {
-
-	/**
-	 * Returns the value of the '<em><b>Annotations</b></em>' containment reference list.
-	 * The list contents are of type {@link org.yakindu.base.types.Annotation}.
-	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Annotations</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
-	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Annotations</em>' containment reference list.
-	 * @see org.yakindu.sct.model.stext.stext.StextPackage#getStatechartSpecification_Annotations()
-	 * @model containment="true"
-	 * @generated
-	 */
-	EList<Annotation> getAnnotations();
+public interface StatechartSpecification extends ScopedElement, AnnotatableElement {
 } // StatechartSpecification

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/StextPackage.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/StextPackage.java
@@ -227,13 +227,22 @@ public interface StextPackage extends EPackage {
 	int STATECHART_SPECIFICATION__ANNOTATIONS = SGraphPackage.SCOPED_ELEMENT_FEATURE_COUNT + 0;
 
 	/**
+	 * The feature id for the '<em><b>Annotation Info</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int STATECHART_SPECIFICATION__ANNOTATION_INFO = SGraphPackage.SCOPED_ELEMENT_FEATURE_COUNT + 1;
+
+	/**
 	 * The number of structural features of the '<em>Statechart Specification</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int STATECHART_SPECIFICATION_FEATURE_COUNT = SGraphPackage.SCOPED_ELEMENT_FEATURE_COUNT + 1;
+	int STATECHART_SPECIFICATION_FEATURE_COUNT = SGraphPackage.SCOPED_ELEMENT_FEATURE_COUNT + 2;
 
 	/**
 	 * The meta object id for the '{@link org.yakindu.sct.model.stext.stext.impl.StateSpecificationImpl <em>State Specification</em>}' class.
@@ -603,15 +612,6 @@ public interface StextPackage extends EPackage {
 	int EVENT_DEFINITION__NAME = TypesPackage.EVENT__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int EVENT_DEFINITION__ID = TypesPackage.EVENT__ID;
-
-	/**
 	 * The feature id for the '<em><b>Annotations</b></em>' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -619,6 +619,24 @@ public interface StextPackage extends EPackage {
 	 * @ordered
 	 */
 	int EVENT_DEFINITION__ANNOTATIONS = TypesPackage.EVENT__ANNOTATIONS;
+
+	/**
+	 * The feature id for the '<em><b>Annotation Info</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int EVENT_DEFINITION__ANNOTATION_INFO = TypesPackage.EVENT__ANNOTATION_INFO;
+
+	/**
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int EVENT_DEFINITION__ID = TypesPackage.EVENT__ID;
 
 	/**
 	 * The feature id for the '<em><b>Static</b></em>' attribute.
@@ -685,15 +703,6 @@ public interface StextPackage extends EPackage {
 	int VARIABLE_DEFINITION__NAME = TypesPackage.PROPERTY__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int VARIABLE_DEFINITION__ID = TypesPackage.PROPERTY__ID;
-
-	/**
 	 * The feature id for the '<em><b>Annotations</b></em>' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -701,6 +710,24 @@ public interface StextPackage extends EPackage {
 	 * @ordered
 	 */
 	int VARIABLE_DEFINITION__ANNOTATIONS = TypesPackage.PROPERTY__ANNOTATIONS;
+
+	/**
+	 * The feature id for the '<em><b>Annotation Info</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int VARIABLE_DEFINITION__ANNOTATION_INFO = TypesPackage.PROPERTY__ANNOTATION_INFO;
+
+	/**
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int VARIABLE_DEFINITION__ID = TypesPackage.PROPERTY__ID;
 
 	/**
 	 * The feature id for the '<em><b>Static</b></em>' attribute.
@@ -785,15 +812,6 @@ public interface StextPackage extends EPackage {
 	int OPERATION_DEFINITION__NAME = TypesPackage.OPERATION__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int OPERATION_DEFINITION__ID = TypesPackage.OPERATION__ID;
-
-	/**
 	 * The feature id for the '<em><b>Annotations</b></em>' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -801,6 +819,24 @@ public interface StextPackage extends EPackage {
 	 * @ordered
 	 */
 	int OPERATION_DEFINITION__ANNOTATIONS = TypesPackage.OPERATION__ANNOTATIONS;
+
+	/**
+	 * The feature id for the '<em><b>Annotation Info</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int OPERATION_DEFINITION__ANNOTATION_INFO = TypesPackage.OPERATION__ANNOTATION_INFO;
+
+	/**
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int OPERATION_DEFINITION__ID = TypesPackage.OPERATION__ID;
 
 	/**
 	 * The feature id for the '<em><b>Static</b></em>' attribute.
@@ -885,15 +921,6 @@ public interface StextPackage extends EPackage {
 	int TYPE_ALIAS_DEFINITION__NAME = TypesPackage.TYPE_ALIAS__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int TYPE_ALIAS_DEFINITION__ID = TypesPackage.TYPE_ALIAS__ID;
-
-	/**
 	 * The feature id for the '<em><b>Annotations</b></em>' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -901,6 +928,24 @@ public interface StextPackage extends EPackage {
 	 * @ordered
 	 */
 	int TYPE_ALIAS_DEFINITION__ANNOTATIONS = TypesPackage.TYPE_ALIAS__ANNOTATIONS;
+
+	/**
+	 * The feature id for the '<em><b>Annotation Info</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int TYPE_ALIAS_DEFINITION__ANNOTATION_INFO = TypesPackage.TYPE_ALIAS__ANNOTATION_INFO;
+
+	/**
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int TYPE_ALIAS_DEFINITION__ID = TypesPackage.TYPE_ALIAS__ID;
 
 	/**
 	 * The feature id for the '<em><b>Abstract</b></em>' attribute.
@@ -1659,17 +1704,6 @@ public interface StextPackage extends EPackage {
 	EClass getStatechartSpecification();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link org.yakindu.sct.model.stext.stext.StatechartSpecification#getAnnotations <em>Annotations</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Annotations</em>'.
-	 * @see org.yakindu.sct.model.stext.stext.StatechartSpecification#getAnnotations()
-	 * @see #getStatechartSpecification()
-	 * @generated
-	 */
-	EReference getStatechartSpecification_Annotations();
-
-	/**
 	 * Returns the meta object for class '{@link org.yakindu.sct.model.stext.stext.StateSpecification <em>State Specification</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2279,14 +2313,6 @@ public interface StextPackage extends EPackage {
 		 * @generated
 		 */
 		EClass STATECHART_SPECIFICATION = eINSTANCE.getStatechartSpecification();
-
-		/**
-		 * The meta object literal for the '<em><b>Annotations</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
-		 * @generated
-		 */
-		EReference STATECHART_SPECIFICATION__ANNOTATIONS = eINSTANCE.getStatechartSpecification_Annotations();
 
 		/**
 		 * The meta object literal for the '{@link org.yakindu.sct.model.stext.stext.impl.StateSpecificationImpl <em>State Specification</em>}' class.

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/EntryPointSpecImpl.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/EntryPointSpecImpl.java
@@ -150,7 +150,7 @@ public class EntryPointSpecImpl extends ReactionPropertyImpl implements EntryPoi
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuilder result = new StringBuilder(super.toString());
+		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (entrypoint: ");
 		result.append(entrypoint);
 		result.append(')');

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/ExitPointSpecImpl.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/ExitPointSpecImpl.java
@@ -150,7 +150,7 @@ public class ExitPointSpecImpl extends ReactionPropertyImpl implements ExitPoint
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuilder result = new StringBuilder(super.toString());
+		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (exitpoint: ");
 		result.append(exitpoint);
 		result.append(')');

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/ImportScopeImpl.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/ImportScopeImpl.java
@@ -134,7 +134,7 @@ public class ImportScopeImpl extends StatechartScopeImpl implements ImportScope 
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuilder result = new StringBuilder(super.toString());
+		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (imports: ");
 		result.append(imports);
 		result.append(')');

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/InterfaceScopeImpl.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/InterfaceScopeImpl.java
@@ -183,7 +183,7 @@ public class InterfaceScopeImpl extends StatechartScopeImpl implements Interface
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuilder result = new StringBuilder(super.toString());
+		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (name: ");
 		result.append(name);
 		result.append(')');

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/StatechartSpecificationImpl.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/StatechartSpecificationImpl.java
@@ -4,13 +4,17 @@ package org.yakindu.sct.model.stext.stext.impl;
 
 import java.util.Collection;
 
+import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.InternalEList;
+import org.yakindu.base.types.AnnotatableElement;
 import org.yakindu.base.types.Annotation;
+import org.yakindu.base.types.TypesPackage;
 import org.yakindu.sct.model.sgraph.impl.ScopedElementImpl;
 import org.yakindu.sct.model.stext.stext.StatechartSpecification;
 import org.yakindu.sct.model.stext.stext.StextPackage;
@@ -24,6 +28,7 @@ import org.yakindu.sct.model.stext.stext.StextPackage;
  * </p>
  * <ul>
  *   <li>{@link org.yakindu.sct.model.stext.stext.impl.StatechartSpecificationImpl#getAnnotations <em>Annotations</em>}</li>
+ *   <li>{@link org.yakindu.sct.model.stext.stext.impl.StatechartSpecificationImpl#getAnnotationInfo <em>Annotation Info</em>}</li>
  * </ul>
  *
  * @generated
@@ -38,6 +43,15 @@ public class StatechartSpecificationImpl extends ScopedElementImpl implements St
 	 * @ordered
 	 */
 	protected EList<Annotation> annotations;
+	/**
+	 * The cached value of the '{@link #getAnnotationInfo() <em>Annotation Info</em>}' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getAnnotationInfo()
+	 * @generated
+	 * @ordered
+	 */
+	protected AnnotatableElement annotationInfo;
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -62,6 +76,7 @@ public class StatechartSpecificationImpl extends ScopedElementImpl implements St
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<Annotation> getAnnotations() {
 		if (annotations == null) {
 			annotations = new EObjectContainmentEList<Annotation>(Annotation.class, this, StextPackage.STATECHART_SPECIFICATION__ANNOTATIONS);
@@ -75,10 +90,72 @@ public class StatechartSpecificationImpl extends ScopedElementImpl implements St
 	 * @generated
 	 */
 	@Override
+	public AnnotatableElement getAnnotationInfo() {
+		return annotationInfo;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public NotificationChain basicSetAnnotationInfo(AnnotatableElement newAnnotationInfo, NotificationChain msgs) {
+		AnnotatableElement oldAnnotationInfo = annotationInfo;
+		annotationInfo = newAnnotationInfo;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, StextPackage.STATECHART_SPECIFICATION__ANNOTATION_INFO, oldAnnotationInfo, newAnnotationInfo);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setAnnotationInfo(AnnotatableElement newAnnotationInfo) {
+		if (newAnnotationInfo != annotationInfo) {
+			NotificationChain msgs = null;
+			if (annotationInfo != null)
+				msgs = ((InternalEObject)annotationInfo).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - StextPackage.STATECHART_SPECIFICATION__ANNOTATION_INFO, null, msgs);
+			if (newAnnotationInfo != null)
+				msgs = ((InternalEObject)newAnnotationInfo).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - StextPackage.STATECHART_SPECIFICATION__ANNOTATION_INFO, null, msgs);
+			msgs = basicSetAnnotationInfo(newAnnotationInfo, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, StextPackage.STATECHART_SPECIFICATION__ANNOTATION_INFO, newAnnotationInfo, newAnnotationInfo));
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated NOT
+	 */
+	@Override
+	public Annotation getAnnotationOfType(String typeName) {
+		EList<Annotation> annotations = getAnnotations();
+		for (Annotation annotation : annotations) {
+			if (typeName.equals(annotation.getType().getName())) {
+				return annotation;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
 			case StextPackage.STATECHART_SPECIFICATION__ANNOTATIONS:
 				return ((InternalEList<?>)getAnnotations()).basicRemove(otherEnd, msgs);
+			case StextPackage.STATECHART_SPECIFICATION__ANNOTATION_INFO:
+				return basicSetAnnotationInfo(null, msgs);
 		}
 		return super.eInverseRemove(otherEnd, featureID, msgs);
 	}
@@ -93,6 +170,8 @@ public class StatechartSpecificationImpl extends ScopedElementImpl implements St
 		switch (featureID) {
 			case StextPackage.STATECHART_SPECIFICATION__ANNOTATIONS:
 				return getAnnotations();
+			case StextPackage.STATECHART_SPECIFICATION__ANNOTATION_INFO:
+				return getAnnotationInfo();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -110,6 +189,9 @@ public class StatechartSpecificationImpl extends ScopedElementImpl implements St
 				getAnnotations().clear();
 				getAnnotations().addAll((Collection<? extends Annotation>)newValue);
 				return;
+			case StextPackage.STATECHART_SPECIFICATION__ANNOTATION_INFO:
+				setAnnotationInfo((AnnotatableElement)newValue);
+				return;
 		}
 		super.eSet(featureID, newValue);
 	}
@@ -125,6 +207,9 @@ public class StatechartSpecificationImpl extends ScopedElementImpl implements St
 			case StextPackage.STATECHART_SPECIFICATION__ANNOTATIONS:
 				getAnnotations().clear();
 				return;
+			case StextPackage.STATECHART_SPECIFICATION__ANNOTATION_INFO:
+				setAnnotationInfo((AnnotatableElement)null);
+				return;
 		}
 		super.eUnset(featureID);
 	}
@@ -139,8 +224,44 @@ public class StatechartSpecificationImpl extends ScopedElementImpl implements St
 		switch (featureID) {
 			case StextPackage.STATECHART_SPECIFICATION__ANNOTATIONS:
 				return annotations != null && !annotations.isEmpty();
+			case StextPackage.STATECHART_SPECIFICATION__ANNOTATION_INFO:
+				return annotationInfo != null;
 		}
 		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public int eBaseStructuralFeatureID(int derivedFeatureID, Class<?> baseClass) {
+		if (baseClass == AnnotatableElement.class) {
+			switch (derivedFeatureID) {
+				case StextPackage.STATECHART_SPECIFICATION__ANNOTATIONS: return TypesPackage.ANNOTATABLE_ELEMENT__ANNOTATIONS;
+				case StextPackage.STATECHART_SPECIFICATION__ANNOTATION_INFO: return TypesPackage.ANNOTATABLE_ELEMENT__ANNOTATION_INFO;
+				default: return -1;
+			}
+		}
+		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public int eDerivedStructuralFeatureID(int baseFeatureID, Class<?> baseClass) {
+		if (baseClass == AnnotatableElement.class) {
+			switch (baseFeatureID) {
+				case TypesPackage.ANNOTATABLE_ELEMENT__ANNOTATIONS: return StextPackage.STATECHART_SPECIFICATION__ANNOTATIONS;
+				case TypesPackage.ANNOTATABLE_ELEMENT__ANNOTATION_INFO: return StextPackage.STATECHART_SPECIFICATION__ANNOTATION_INFO;
+				default: return -1;
+			}
+		}
+		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
 	}
 
 } //StatechartSpecificationImpl

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/StextFactoryImpl.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/StextFactoryImpl.java
@@ -8,6 +8,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.impl.EFactoryImpl;
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
+import org.yakindu.sct.model.stext.stext.*;
 import org.yakindu.sct.model.stext.stext.ActiveStateReferenceExpression;
 import org.yakindu.sct.model.stext.stext.AlwaysEvent;
 import org.yakindu.sct.model.stext.stext.BuiltinEventSpec;

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/StextPackageImpl.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/StextPackageImpl.java
@@ -346,7 +346,7 @@ public class StextPackageImpl extends EPackageImpl implements StextPackage {
 
 	/**
 	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
-	 *
+	 * 
 	 * <p>This method is used to initialize {@link StextPackage#eINSTANCE} when that field is accessed.
 	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
 	 * <!-- begin-user-doc -->
@@ -360,8 +360,7 @@ public class StextPackageImpl extends EPackageImpl implements StextPackage {
 		if (isInited) return (StextPackage)EPackage.Registry.INSTANCE.getEPackage(StextPackage.eNS_URI);
 
 		// Obtain or create and register package
-		Object registeredStextPackage = EPackage.Registry.INSTANCE.get(eNS_URI);
-		StextPackageImpl theStextPackage = registeredStextPackage instanceof StextPackageImpl ? (StextPackageImpl)registeredStextPackage : new StextPackageImpl();
+		StextPackageImpl theStextPackage = (StextPackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof StextPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new StextPackageImpl());
 
 		isInited = true;
 
@@ -380,6 +379,7 @@ public class StextPackageImpl extends EPackageImpl implements StextPackage {
 		// Mark meta-data to indicate it can't be changed
 		theStextPackage.freeze();
 
+  
 		// Update the registry and return the package
 		EPackage.Registry.INSTANCE.put(StextPackage.eNS_URI, theStextPackage);
 		return theStextPackage;
@@ -473,15 +473,6 @@ public class StextPackageImpl extends EPackageImpl implements StextPackage {
 	 */
 	public EClass getStatechartSpecification() {
 		return statechartSpecificationEClass;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EReference getStatechartSpecification_Annotations() {
-		return (EReference)statechartSpecificationEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
@@ -959,7 +950,6 @@ public class StextPackageImpl extends EPackageImpl implements StextPackage {
 		createEReference(transitionRootEClass, TRANSITION_ROOT__DEF);
 
 		statechartSpecificationEClass = createEClass(STATECHART_SPECIFICATION);
-		createEReference(statechartSpecificationEClass, STATECHART_SPECIFICATION__ANNOTATIONS);
 
 		stateSpecificationEClass = createEClass(STATE_SPECIFICATION);
 		createEReference(stateSpecificationEClass, STATE_SPECIFICATION__SCOPE);
@@ -1078,6 +1068,7 @@ public class StextPackageImpl extends EPackageImpl implements StextPackage {
 		stateRootEClass.getESuperTypes().add(this.getDefRoot());
 		transitionRootEClass.getESuperTypes().add(this.getDefRoot());
 		statechartSpecificationEClass.getESuperTypes().add(theSGraphPackage.getScopedElement());
+		statechartSpecificationEClass.getESuperTypes().add(theTypesPackage.getAnnotatableElement());
 		statechartScopeEClass.getESuperTypes().add(theSGraphPackage.getScope());
 		interfaceScopeEClass.getESuperTypes().add(this.getStatechartScope());
 		interfaceScopeEClass.getESuperTypes().add(theBasePackage.getNamedElement());
@@ -1122,7 +1113,6 @@ public class StextPackageImpl extends EPackageImpl implements StextPackage {
 		initEReference(getTransitionRoot_Def(), this.getTransitionSpecification(), null, "def", null, 0, 1, TransitionRoot.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(statechartSpecificationEClass, StatechartSpecification.class, "StatechartSpecification", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getStatechartSpecification_Annotations(), theTypesPackage.getAnnotation(), null, "annotations", null, 0, -1, StatechartSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(stateSpecificationEClass, StateSpecification.class, "StateSpecification", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getStateSpecification_Scope(), theSGraphPackage.getScope(), null, "scope", null, 0, 1, StateSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/TimeEventSpecImpl.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/TimeEventSpecImpl.java
@@ -284,7 +284,7 @@ public class TimeEventSpecImpl extends EventSpecImpl implements TimeEventSpec {
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuilder result = new StringBuilder(super.toString());
+		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (type: ");
 		result.append(type);
 		result.append(", unit: ");

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/TypeAliasDefinitionImpl.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/impl/TypeAliasDefinitionImpl.java
@@ -187,7 +187,7 @@ public class TypeAliasDefinitionImpl extends TypeAliasImpl implements TypeAliasD
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuilder result = new StringBuilder(super.toString());
+		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (static: ");
 		result.append(static_);
 		result.append(')');

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/util/StextAdapterFactory.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/util/StextAdapterFactory.java
@@ -24,6 +24,7 @@ import org.yakindu.sct.model.sgraph.ReactionProperty;
 import org.yakindu.sct.model.sgraph.Scope;
 import org.yakindu.sct.model.sgraph.ScopedElement;
 import org.yakindu.sct.model.sgraph.Trigger;
+import org.yakindu.sct.model.stext.stext.*;
 import org.yakindu.sct.model.stext.stext.ActiveStateReferenceExpression;
 import org.yakindu.sct.model.stext.stext.AlwaysEvent;
 import org.yakindu.sct.model.stext.stext.BuiltinEventSpec;
@@ -262,6 +263,10 @@ public class StextAdapterFactory extends AdapterFactoryImpl {
 				return createScopedElementAdapter();
 			}
 			@Override
+			public Adapter caseAnnotatableElement(AnnotatableElement object) {
+				return createAnnotatableElementAdapter();
+			}
+			@Override
 			public Adapter caseScope(Scope object) {
 				return createScopeAdapter();
 			}
@@ -272,10 +277,6 @@ public class StextAdapterFactory extends AdapterFactoryImpl {
 			@Override
 			public Adapter caseTypedElement(TypedElement object) {
 				return createTypedElementAdapter();
-			}
-			@Override
-			public Adapter caseAnnotatableElement(AnnotatableElement object) {
-				return createAnnotatableElementAdapter();
 			}
 			@Override
 			public Adapter casePackageMember(PackageMember object) {

--- a/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/util/StextSwitch.java
+++ b/plugins/org.yakindu.sct.model.stext/emf-gen/org/yakindu/sct/model/stext/stext/util/StextSwitch.java
@@ -23,6 +23,7 @@ import org.yakindu.sct.model.sgraph.ReactionProperty;
 import org.yakindu.sct.model.sgraph.Scope;
 import org.yakindu.sct.model.sgraph.ScopedElement;
 import org.yakindu.sct.model.sgraph.Trigger;
+import org.yakindu.sct.model.stext.stext.*;
 import org.yakindu.sct.model.stext.stext.ActiveStateReferenceExpression;
 import org.yakindu.sct.model.stext.stext.AlwaysEvent;
 import org.yakindu.sct.model.stext.stext.BuiltinEventSpec;
@@ -154,6 +155,7 @@ public class StextSwitch<T> extends Switch<T> {
 				StatechartSpecification statechartSpecification = (StatechartSpecification)theEObject;
 				T result = caseStatechartSpecification(statechartSpecification);
 				if (result == null) result = caseScopedElement(statechartSpecification);
+				if (result == null) result = caseAnnotatableElement(statechartSpecification);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}

--- a/plugins/org.yakindu.sct.model.stext/model/SText.ecore
+++ b/plugins/org.yakindu.sct.model.stext/model/SText.ecore
@@ -18,11 +18,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="def" eType="#//TransitionSpecification"
         containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="StatechartSpecification" eSuperTypes="../../org.yakindu.sct.model.sgraph/model/emf/sgraph.ecore#//ScopedElement">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="annotations" upperBound="-1"
-        eType="ecore:EClass ../../org.yakindu.base.types/model/types.ecore#//Annotation"
-        containment="true"/>
-  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="StatechartSpecification" eSuperTypes="../../org.yakindu.sct.model.sgraph/model/emf/sgraph.ecore#//ScopedElement ../../org.yakindu.base.types/model/types.ecore#//AnnotatableElement"/>
   <eClassifiers xsi:type="ecore:EClass" name="StateSpecification">
     <eStructuralFeatures xsi:type="ecore:EReference" name="scope" eType="ecore:EClass ../../org.yakindu.sct.model.sgraph/model/emf/sgraph.ecore#//Scope"
         containment="true"/>

--- a/plugins/org.yakindu.sct.model.stext/model/SText.genmodel
+++ b/plugins/org.yakindu.sct.model.stext/model/SText.genmodel
@@ -3,7 +3,7 @@
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/org.yakindu.sct.model.stext/emf-gen" editDirectory="/org.yakindu.sct.model.stext.edit/src"
     editorDirectory="/org.yakindu.sct.model.stext.editor/src" modelPluginID="org.yakindu.sct.model.stext"
     forceOverwrite="true" modelName="SText" updateClasspath="false" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
-    importerID="org.eclipse.emf.importer.ecore" complianceLevel="5.0" copyrightFields="false"
+    importerID="org.eclipse.emf.importer.ecore" complianceLevel="8.0" copyrightFields="false"
     editPluginID="org.yakindu.sct.model.stext.edit" editorPluginID="org.yakindu.sct.model.stext.editor"
     runtimeVersion="2.8" usedGenPackages="../../org.yakindu.base.expressions/model/Expressions.genmodel#//expressions ../../org.yakindu.base.types/model/base.genmodel#//base ../../org.yakindu.base.types/model/types.genmodel#//types ../../org.yakindu.sct.model.sgraph/model/emf/sgraph.genmodel#//sgraph">
   <foreignModel>SText.ecore</foreignModel>
@@ -32,9 +32,7 @@
     <genClasses ecoreClass="SText.ecore#//TransitionRoot">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference SText.ecore#//TransitionRoot/def"/>
     </genClasses>
-    <genClasses ecoreClass="SText.ecore#//StatechartSpecification">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference SText.ecore#//StatechartSpecification/annotations"/>
-    </genClasses>
+    <genClasses ecoreClass="SText.ecore#//StatechartSpecification"/>
     <genClasses ecoreClass="SText.ecore#//StateSpecification">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference SText.ecore#//StateSpecification/scope"/>
     </genClasses>


### PR DESCRIPTION
Fix #2477: During some restructuring work in the meta model, we forgot to make the StatechartSpecification an AnnotatableElement.