### PR TITLE
resolves classloading issues for stext elements

### DIFF
--- a/plugins/org.yakindu.sct.generator.runner/META-INF/MANIFEST.MF
+++ b/plugins/org.yakindu.sct.generator.runner/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.yakindu.sct.generator.genmodel,
  org.yakindu.sct.commons,
  org.eclipse.jdt.core,
- org.eclipse.emf.workspace
+ org.eclipse.emf.workspace,
+ org.yakindu.sct.model.stext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.yakindu.sct.generator.runner


### PR DESCRIPTION
fixes #1519 

With the dependency to SText the equinox class loader can reuse the already loaded Stext classes 