### PR TITLE
Handling feature call chains during simulation

### DIFF
--- a/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/AbstractOperationExecutor.xtend
+++ b/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/AbstractOperationExecutor.xtend
@@ -13,11 +13,11 @@ package org.yakindu.base.expressions.interpreter
 import com.google.inject.Inject
 import java.util.List
 import org.eclipse.emf.ecore.EObject
-import org.yakindu.base.base.NamedElement
 import org.yakindu.base.expressions.expressions.Argument
-import org.yakindu.base.expressions.expressions.ElementReferenceExpression
+import org.yakindu.base.expressions.expressions.ArgumentExpression
 import org.yakindu.base.expressions.expressions.FeatureCall
 import org.yakindu.base.expressions.expressions.util.ArgumentSorter
+import org.yakindu.base.expressions.util.ExpressionExtensions
 import org.yakindu.base.types.Operation
 import org.yakindu.sct.model.sruntime.ExecutionContext
 
@@ -28,29 +28,21 @@ import org.yakindu.sct.model.sruntime.ExecutionContext
 abstract class AbstractOperationExecutor implements IOperationExecutor {
 
 	@Inject extension protected IExpressionInterpreter interpreter
+	
+	@Inject extension ExpressionExtensions
 
-	def dispatch getOperation(ElementReferenceExpression it) {
-		reference as Operation
+	def getOperation(ArgumentExpression it) {
+		it.featureOrReference as Operation
 	}
 
-	def dispatch getOperation(FeatureCall it) {
-		feature as Operation
-	}
-
-	def dispatch NamedElement getOwner(FeatureCall it) {
-		val owner = owner
-		if (owner instanceof ElementReferenceExpression) {
-			return owner.reference as NamedElement
-		} else if (owner instanceof FeatureCall) {
-			return owner.feature as NamedElement
+	def dispatch EObject getOwner(FeatureCall it) {
+		val owner = it.owner
+		if (owner instanceof ArgumentExpression) {
+			return owner.featureOrReference
 		}
 	}
 
-	def dispatch NamedElement getOwner(ElementReferenceExpression it) {
-		null
-	}
-
-	def dispatch NamedElement getOwner(EObject it) {}
+	def dispatch EObject getOwner(ArgumentExpression it) {}
 
 	def executeArguments(List<Argument> arguments, ExecutionContext context, Operation operation) {
 		val orderedExpressions = ArgumentSorter.getOrderedExpressions(arguments, operation)

--- a/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/AbstractOperationExecutor.xtend
+++ b/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/AbstractOperationExecutor.xtend
@@ -41,8 +41,9 @@ abstract class AbstractOperationExecutor implements IOperationExecutor {
 		val owner = owner
 		if (owner instanceof ElementReferenceExpression) {
 			return owner.reference as NamedElement
-		} else
-			owner.owner
+		} else if (owner instanceof FeatureCall) {
+			return owner.feature as NamedElement
+		}
 	}
 
 	def dispatch NamedElement getOwner(ElementReferenceExpression it) {

--- a/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/DefaultExpressionInterpreter.xtend
+++ b/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/DefaultExpressionInterpreter.xtend
@@ -276,46 +276,46 @@ class DefaultExpressionInterpreter extends AbstractExpressionInterpreter impleme
 
 	def executeElementReferenceExpression(ElementReferenceExpression expression) {
 		val executionSlot = context.resolve(expression)
-		return executeArgumentExpression(expression, expression.reference, executionSlot)
+		return doExecute(expression.reference, executionSlot, expression)
 	}
 
 	def dispatch Object execute(FeatureCall call) {
 		executeFeatureCall(call)
 	}
 
-	def executeFeatureCall(FeatureCall it) {
+	def executeFeatureCall(FeatureCall call) {
 		var result = null as Object
 		var slot = null as ExecutionSlot
-		for (ArgumentExpression c : toCallStack) {
-			slot = context.resolve(c)
-			result = executeArgumentExpression(c, c.featureOrReference, slot)
+		for (ArgumentExpression exp : call.toCallStack) {
+			slot = context.resolve(exp)
+			result = doExecute(exp.featureOrReference, slot, exp)
 		}
 		return result
 	}
 	
-	def dispatch executeArgumentExpression(ArgumentExpression exp, EObject feature, Void slot) {
+	def dispatch doExecute(EObject feature, Void slot, ArgumentExpression exp) {
 		// fall-back
 		println("No implementation found for " + exp + " -> returning null")
 		null
 	}
 	
-	def dispatch executeArgumentExpression(ArgumentExpression exp, EObject feature, ExecutionVariable slot) {
+	def dispatch doExecute(EObject feature, ExecutionVariable slot, ArgumentExpression exp) {
 		slot.value
 	}
 	
-	def dispatch executeArgumentExpression(ArgumentExpression exp, EObject feature, CompositeSlot slot) {
+	def dispatch doExecute(EObject feature, CompositeSlot slot, ArgumentExpression exp) {
 		slot
 	}
 	
-	def dispatch executeArgumentExpression(ArgumentExpression exp, EObject feature, ExecutionEvent slot) {
-		return slot.raised
+	def dispatch doExecute(EObject feature, ExecutionEvent slot, ArgumentExpression exp) {
+		slot.raised
 	}
 	
-	def dispatch executeArgumentExpression(ArgumentExpression exp, Operation feature, ExecutionEvent slot) {
+	def dispatch doExecute(Operation feature, ExecutionEvent slot, ArgumentExpression exp) {
 		slot.raised = true
 	}
 	
-	def dispatch executeArgumentExpression(ArgumentExpression exp, Operation feature, ExecutionSlot slot) {
+	def dispatch doExecute(Operation feature, ExecutionSlot slot, ArgumentExpression exp) {
 		val executor = operationExecutors.findFirst[canExecute(exp)]
 		if (executor !== null) {
 			val result = executor.executeOperation(exp)
@@ -324,8 +324,8 @@ class DefaultExpressionInterpreter extends AbstractExpressionInterpreter impleme
 		}
 	}
 	
-	def dispatch executeArgumentExpression(ArgumentExpression exp, Enumerator feature, Void slot) {
-		return new Long(feature.literalValue)
+	def dispatch doExecute(Enumerator feature, Void slot, ArgumentExpression exp) {
+		new Long(feature.literalValue)
 	}
 
 	def executeUnaryCoreFunction(Expression statement, String operator) {

--- a/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/DefaultExpressionInterpreter.xtend
+++ b/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/DefaultExpressionInterpreter.xtend
@@ -347,7 +347,7 @@ class DefaultExpressionInterpreter extends AbstractExpressionInterpreter impleme
 		}
 	}
 	
-	def dispatch executeFeatureCall(FeatureCall call, Enumerator feature, ExecutionSlot slot) {
+	def dispatch executeFeatureCall(FeatureCall call, Enumerator feature, Void slot) {
 		return new Long(feature.literalValue)
 	}
 

--- a/plugins/org.yakindu.base.expressions/META-INF/MANIFEST.MF
+++ b/plugins/org.yakindu.base.expressions/META-INF/MANIFEST.MF
@@ -39,6 +39,7 @@ Export-Package: org.yakindu.base.expressions,
  org.yakindu.base.expressions.serializer,
  org.yakindu.base.expressions.services,
  org.yakindu.base.expressions.terminals,
+ org.yakindu.base.expressions.util,
  org.yakindu.base.expressions.validation
 Bundle-ClassPath: .
 Automatic-Module-Name: org.yakindu.base.expressions

--- a/plugins/org.yakindu.base.expressions/src/org/yakindu/base/expressions/util/ExpressionExtensions.xtend
+++ b/plugins/org.yakindu.base.expressions/src/org/yakindu/base/expressions/util/ExpressionExtensions.xtend
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2018 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * 	itemis AG - initial API and implementation
+ * 
+ */
+package org.yakindu.base.expressions.util
+
+import com.google.common.collect.Lists
+import java.util.Collections
+import java.util.List
+import org.yakindu.base.expressions.expressions.ArgumentExpression
+import org.yakindu.base.expressions.expressions.ElementReferenceExpression
+import org.yakindu.base.expressions.expressions.FeatureCall
+import org.yakindu.base.types.Expression
+import org.eclipse.emf.ecore.EObject
+
+/**
+ * Thomas Kutz - Initial API and contribution
+ */
+class ExpressionExtensions {
+
+	/**
+	 * Transforms a feature call to its call stack by traversing through the owner hierarchy
+	 * @return a list of feature calls starting from the root call, 
+	 * i.e. for <code>MyInterface.myVar.x</code> it returns <code>[MyInterface, myVar, x]</code>
+	 */
+	def dispatch List<ArgumentExpression> toCallStack(FeatureCall call) {
+		val callStack = Lists.newArrayList
+		callStack.addAll(call.owner.toCallStack)
+		callStack.add(call)
+		callStack
+	}
+
+	def dispatch List<ArgumentExpression> toCallStack(ElementReferenceExpression ex) {
+		Lists.newArrayList(ex)
+	}
+	
+	def dispatch List<ArgumentExpression> toCallStack(Expression ex) {
+		Collections.emptyList
+	}
+	
+	/**
+	 * Returns getFeature() for FeatureCall and getReference() for ElementReferenceExpression
+	 */
+	def dispatch EObject featureOrReference(ArgumentExpression it) {
+		null
+	}
+	
+	def dispatch EObject featureOrReference(FeatureCall it) {
+		feature
+	}
+	
+	def dispatch EObject featureOrReference(ElementReferenceExpression it) {
+		reference
+	}
+}

--- a/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/view/ExecutionContextLabelProvider.java
+++ b/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/view/ExecutionContextLabelProvider.java
@@ -34,6 +34,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.TreeItem;
 import org.yakindu.base.types.EnumerationType;
 import org.yakindu.base.types.PrimitiveType;
+import org.yakindu.base.types.Type;
 import org.yakindu.sct.model.sruntime.CompositeSlot;
 import org.yakindu.sct.model.sruntime.ExecutionEvent;
 import org.yakindu.sct.model.sruntime.ExecutionOperation;
@@ -126,7 +127,11 @@ public class ExecutionContextLabelProvider extends StyledCellLabelProvider {
 	}
 
 	protected boolean isEnumType(Object element) {
-		return ((ExecutionSlot) element).getType().getOriginType() instanceof EnumerationType;
+		Type type = ((ExecutionSlot) element).getType();
+		if (type == null) {
+			return false;
+		}
+		return type.getOriginType() instanceof EnumerationType;
 	}
 
 	private void updateNameCell(ViewerCell cell) {

--- a/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/util/STextTestScopeProvider.xtend
+++ b/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/util/STextTestScopeProvider.xtend
@@ -173,6 +173,7 @@ class STextTestScopeProvider extends STextScopeProvider {
 		val complexType = factory.createComplexType => [
 			name = "ComplexType"
 			features += createProperty("x", INTEGER)
+			features += createProperty("y", it)
 		]
 		complexType.addToResource
 		complexType

--- a/test-plugins/org.yakindu.sct.simulation.core.sexec.test/src/org/yakindu/sct/model/sexec/interpreter/test/STextInterpreterTest.java
+++ b/test-plugins/org.yakindu.sct.simulation.core.sexec.test/src/org/yakindu/sct/model/sexec/interpreter/test/STextInterpreterTest.java
@@ -556,6 +556,16 @@ public class STextInterpreterTest extends AbstractSTextTest {
 		execute("internal: alias MyComplexType : ComplexType var cpVar : MyComplexType", "cpVar.x = 42");
 		assertEquals(42L, context.getVariable("cpVar.x").getValue());
 	}
+	
+	@Test
+	public void testInnerComplexTypeAssignment() {
+		execute("internal: var cpVar : ComplexType var intVar : integer", "cpVar.y.x = 42");
+		assertEquals(42L, context.getVariable("cpVar.y.x").getValue());
+		assertEquals(0, context.getVariable("intVar").getValue());
+		
+		execute("internal: var cpVar : ComplexType var intVar : integer", "intVar = cpVar.y.x");
+		assertEquals(42L, context.getVariable("intVar").getValue());
+	}
 
 	// Convenience...
 
@@ -611,12 +621,26 @@ public class STextInterpreterTest extends AbstractSTextTest {
 		cpVar.setName("cpVar");
 		cpVar.setFqName("cpVar");
 		
-		ExecutionVariable featureVar = new ExecutionVariableImpl();
-		featureVar.setName("x");
-		featureVar.setFqName("cpVar.x");
-		featureVar.setType(typeSystem.getType(GenericTypeSystem.INTEGER));
-		featureVar.setValue(0);
-		cpVar.getSlots().add(featureVar);
+		ExecutionVariable featureX = new ExecutionVariableImpl();
+		featureX.setName("x");
+		featureX.setFqName("cpVar.x");
+		featureX.setType(typeSystem.getType(GenericTypeSystem.INTEGER));
+		featureX.setValue(0);
+		
+		CompositeSlot featureY = new CompositeSlotImpl();
+		featureY.setName("y");
+		featureY.setFqName("cpVar.y");
+		
+		ExecutionVariable featureYA = new ExecutionVariableImpl();
+		featureYA.setName("x");
+		featureYA.setFqName("cpVar.y.x");
+		featureYA.setType(typeSystem.getType(GenericTypeSystem.INTEGER));
+		featureYA.setValue(0);
+		featureY.getSlots().add(featureYA);
+		
+		cpVar.getSlots().add(featureX);
+		cpVar.getSlots().add(featureY);
+		
 		context.getSlots().add(cpVar);
 	}
 


### PR DESCRIPTION
Changes in interpreter so that feature calls like `myList.get(5).doSomething()` will be interpreted step by step, starting with resolving `myList`, then executing operation `get(5)` and storing the result in the execution slot, and finally invoking `doSomething` on that result.

Previously, we directly tried to invoke `doSomething` on the slot for `get()` operation which has no value yet.