### PR TITLE
Better status messages on generation failures

### DIFF
--- a/plugins/org.yakindu.sct.generator.core/src/org/yakindu/sct/generator/core/execution/AbstractGeneratorEntryExecutor.java
+++ b/plugins/org.yakindu.sct.generator.core/src/org/yakindu/sct/generator/core/execution/AbstractGeneratorEntryExecutor.java
@@ -64,7 +64,7 @@ public abstract class AbstractGeneratorEntryExecutor implements IGeneratorEntryE
 				execute(factory.create(entry), entry);
 			} catch (Exception ex) {
 				logger.logError(ex);
-				status = new Status(IStatus.ERROR, PLUGIN_ID, ex.getMessage());
+				status = new Status(IStatus.ERROR, PLUGIN_ID, ex.toString());
 			}
 		} else {
 			status = new Status(IStatus.ERROR, PLUGIN_ID,


### PR DESCRIPTION
Throwable.toString() concatenates exception class name with exception message, which gives more information as some exceptions (e.g. NPE) do not come with a message.