### PR TITLE
WIP: check internal event raised outside of downstream scope

### DIFF
--- a/plugins/org.yakindu.sct.domain.generic.editor/META-INF/MANIFEST.MF
+++ b/plugins/org.yakindu.sct.domain.generic.editor/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.yakindu.sct.ui.editor,
  org.yakindu.sct.model.stext.ui,
  org.eclipse.xtext.ui,
  org.eclipse.xtext.ui.shared,
- org.yakindu.sct.model.sgraph.ui
+ org.yakindu.sct.model.sgraph.ui,
+ org.yakindu.sct.model.sexec
 Import-Package: com.google.inject.multibindings;version="1.3.0"
 Export-Package: org.yakindu.sct.domain.generic.editor
 Automatic-Module-Name: org.yakindu.sct.domain.generic.editor

--- a/plugins/org.yakindu.sct.domain.generic.editor/src/org/yakindu/sct/domain/generic/editor/GenericEditorModule.java
+++ b/plugins/org.yakindu.sct.domain.generic.editor/src/org/yakindu/sct/domain/generic/editor/GenericEditorModule.java
@@ -11,15 +11,18 @@
 package org.yakindu.sct.domain.generic.editor;
 
 import org.eclipse.xtext.service.AbstractGenericModule;
+import org.eclipse.xtext.service.SingletonBinding;
 import org.eclipse.xtext.ui.editor.validation.IValidationIssueProcessor;
 import org.eclipse.xtext.ui.editor.validation.MarkerCreator;
 import org.eclipse.xtext.ui.validation.MarkerTypeProvider;
 import org.eclipse.xtext.validation.IDiagnosticConverter;
 import org.eclipse.xtext.validation.IResourceValidator;
+import org.yakindu.sct.model.sexec.validation.SExecValidator;
 import org.yakindu.sct.model.sgraph.ui.validation.SCTDiagnosticConverterImpl;
 import org.yakindu.sct.model.sgraph.ui.validation.SCTMarkerCreator;
 import org.yakindu.sct.model.sgraph.ui.validation.SCTMarkerTypeProvider;
 import org.yakindu.sct.model.stext.resource.SCTResourceValidatorImpl;
+import org.yakindu.sct.model.stext.validation.STextValidator;
 import org.yakindu.sct.refactoring.proposals.RefactoringProposalProvider;
 import org.yakindu.sct.ui.editor.editor.proposals.SmartEditProposalProvider;
 import org.yakindu.sct.ui.editor.proposals.IEditProposalProvider;
@@ -61,6 +64,11 @@ public class GenericEditorModule extends AbstractGenericModule {
 
 	public Class<? extends MarkerTypeProvider> bindMarkerTypeProvider() {
 		return SCTMarkerTypeProvider.class;
+	}
+	
+	@SingletonBinding(eager = true)
+	public Class<? extends STextValidator> bindSTextValidator() {
+		return SExecValidator.class;
 	}
 
 }

--- a/plugins/org.yakindu.sct.model.sexec/META-INF/MANIFEST.MF
+++ b/plugins/org.yakindu.sct.model.sexec/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Export-Package: org.yakindu.sct.model.sexec,
  org.yakindu.sct.model.sexec.naming.tree,
  org.yakindu.sct.model.sexec.transformation,
  org.yakindu.sct.model.sexec.transformation.ng,
- org.yakindu.sct.model.sexec.util
+ org.yakindu.sct.model.sexec.util,
+ org.yakindu.sct.model.sexec.validation
 Require-Bundle: com.google.inject,
  org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
@@ -24,5 +25,6 @@ Require-Bundle: com.google.inject,
  org.yakindu.base.types;visibility:=reexport,
  org.yakindu.base.expressions;visibility:=reexport,
  org.yakindu.sct.model.stext,
- org.yakindu.sct.model.sgraph;visibility:=reexport
+ org.yakindu.sct.model.sgraph;visibility:=reexport,
+ org.yakindu.sct.domain
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/validation/SExecRuntimeModule.java
+++ b/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/validation/SExecRuntimeModule.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2019 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * 	itemis AG - initial API and implementation
+ *
+ */
+package org.yakindu.sct.model.sexec.validation;
+
+import org.eclipse.xtext.naming.IQualifiedNameProvider;
+import org.eclipse.xtext.service.SingletonBinding;
+import org.yakindu.base.types.inferrer.ITypeSystemInferrer;
+import org.yakindu.base.types.typesystem.GenericTypeSystem;
+import org.yakindu.base.types.typesystem.ITypeSystem;
+import org.yakindu.sct.model.sexec.ExecutionFlow;
+import org.yakindu.sct.model.sexec.impl.ExecutionFlowImpl;
+import org.yakindu.sct.model.sexec.transformation.IModelSequencer;
+import org.yakindu.sct.model.stext.STextRuntimeModule;
+import org.yakindu.sct.model.stext.inferrer.STextTypeInferrer;
+import org.yakindu.sct.model.stext.naming.StextNameProvider;
+import org.yakindu.sct.model.stext.validation.STextValidator;
+
+import com.google.inject.Binder;
+import com.google.inject.name.Names;
+
+public class SExecRuntimeModule extends STextRuntimeModule {
+
+	public void configure(Binder binder) {
+		super.configure(binder);
+		binder.bind(Boolean.class).annotatedWith(Names.named(IModelSequencer.ADD_TRACES)).toInstance(Boolean.TRUE);
+		binder.bind(ITypeSystem.class).toInstance(getTypeSystem());
+		binder.bind(IQualifiedNameProvider.class).to(StextNameProvider.class);
+	}
+
+	@Override
+	@SingletonBinding(eager = true)
+	public Class<? extends STextValidator> bindSTextValidator() {
+		return SExecValidator.class;
+	}
+
+	public Class<? extends IQualifiedNameProvider> bindIQualifiedNameProvider() {
+		return StextNameProvider.class;
+	}
+
+	public Class<? extends ITypeSystemInferrer> bindITypeSystemInferrer() {
+		return STextTypeInferrer.class;
+	}
+
+	protected ITypeSystem getTypeSystem() {
+		return GenericTypeSystem.getInstance();
+	}
+
+}

--- a/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/validation/SExecValidationMessages.java
+++ b/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/validation/SExecValidationMessages.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2019 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * 	itemis AG - initial API and implementation
+ *
+ */
+package org.yakindu.sct.model.sexec.validation;
+
+public interface SExecValidationMessages {
+	public static final String EVENT_NOT_VISIBLE_DOWNSTREAM = "Event is always inactive here as it is raised later (in a lower priority region).";
+}

--- a/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/validation/SExecValidator.xtend
+++ b/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/validation/SExecValidator.xtend
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2019 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * 	itemis AG - initial API and implementation
+ *
+ */
+package org.yakindu.sct.model.sexec.validation;
+
+import com.google.inject.Inject
+import org.eclipse.xtext.validation.Check
+import org.eclipse.xtext.validation.CheckType
+import org.eclipse.xtext.validation.ComposedChecks
+import org.yakindu.base.expressions.validation.ExpressionsValidator
+import org.yakindu.sct.model.sexec.ExecutionFlow
+import org.yakindu.sct.model.sexec.transformation.SexecElementMapping
+import org.yakindu.sct.model.sexec.transformation.StateVectorBuilder
+import org.yakindu.sct.model.sexec.transformation.StructureMapping
+import org.yakindu.sct.model.sgraph.Statechart
+import org.yakindu.sct.model.sgraph.validation.SGraphJavaValidator
+import org.yakindu.sct.model.stext.validation.STextNamesAreUniqueValidator
+import org.yakindu.sct.model.stext.validation.STextValidator
+
+@ComposedChecks(validators=#[SGraphJavaValidator, ExpressionsValidator, STextNamesAreUniqueValidator])
+class SExecValidator extends STextValidator{
+
+	@Inject extension SexecElementMapping mapping
+	@Inject extension StructureMapping structureMapping
+	@Inject extension StateVectorBuilder svBuilder
+
+	@Check(CheckType.NORMAL)
+	def void checkInternalEventRaisedOutsideOfDownstreamScope(Statechart sc) {
+		// Check all internal events in cycle based execution schema.
+		
+		var ExecutionFlow ef = sc.create
+		
+		// from ModelSequencer
+		sc.mapScopes(ef) 
+		sc.mapRegularStates(ef)
+		sc.mapPseudoStates(ef)
+		sc.mapRegions(ef)
+		sc.mapTimeEvents(ef)
+		ef.defineStateVector(sc)
+		
+		var stateVector = ef.getStateVector()
+		
+		System.out.println("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+		
+		}
+
+}

--- a/test-plugins/org.yakindu.sct.model.sexec.test/src/org/yakindu/sct/model/sexec/transformation/test/AllTests.java
+++ b/test-plugins/org.yakindu.sct.model.sexec.test/src/org/yakindu/sct/model/sexec/transformation/test/AllTests.java
@@ -13,6 +13,7 @@ package org.yakindu.sct.model.sexec.transformation.test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+import org.yakindu.sct.model.sexec.transformation.test.validation.SExecValidationTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({ 
@@ -34,7 +35,8 @@ import org.junit.runners.Suite.SuiteClasses;
 		StatechartExtensionsTest.class,
 		StringTreeNodeTest.class,
 		TreeNamingServiceTest.class,
-		NullCallTest.class
+		NullCallTest.class,
+		SExecValidationTest.class
 		})
 public class AllTests {
 

--- a/test-plugins/org.yakindu.sct.model.sexec.test/src/org/yakindu/sct/model/sexec/transformation/test/validation/SExecValidationTest.java
+++ b/test-plugins/org.yakindu.sct.model.sexec.test/src/org/yakindu/sct/model/sexec/transformation/test/validation/SExecValidationTest.java
@@ -1,0 +1,37 @@
+package org.yakindu.sct.model.sexec.transformation.test.validation;
+
+
+import static org.yakindu.sct.test.models.AbstractTestModelsUtil.VALIDATION_TESTMODEL_DIR;
+import static org.yakindu.sct.model.sexec.validation.SExecValidationMessages.*;
+
+import org.eclipse.xtext.junit4.InjectWith;
+import org.eclipse.xtext.junit4.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.yakindu.sct.model.sgraph.Statechart;
+import org.yakindu.sct.model.stext.test.util.STextInjectorProvider;
+import org.yakindu.sct.model.stext.test.validation.STextJavaValidatorTest;
+import org.yakindu.sct.test.models.AbstractTestModelsUtil;
+
+@RunWith(XtextRunner.class)
+@InjectWith(STextInjectorProvider.class)
+public class SExecValidationTest extends STextJavaValidatorTest {
+
+	@Test
+	public void checkInternalEventRaisedOutsideOfDownstreamScope() {
+		statechart = AbstractTestModelsUtil
+				.loadStatechart(VALIDATION_TESTMODEL_DIR + "InternalEventRaisedOutsideOfDownstreamScope.sct");
+		doValidateAllContents(Statechart.class);
+		assertIssueCount(diagnostics, 1);
+		assertWarning(diagnostics, EVENT_NOT_VISIBLE_DOWNSTREAM);
+	}
+	
+	@Test
+	public void checkInternalEventRaisedInsideOfDownstreamScope() {
+		statechart = AbstractTestModelsUtil
+				.loadStatechart(VALIDATION_TESTMODEL_DIR + "InternalEventRaisedInsideOfDownstreamScope.sct");
+		doValidateAllContents(Statechart.class);
+		assertIssueCount(diagnostics, 0);
+	}
+	
+}

--- a/test-plugins/org.yakindu.sct.test.models/testmodels/validation/InternalEventRaisedInsideOfDownstreamScope.sct
+++ b/test-plugins/org.yakindu.sct.test.models/testmodels/validation/InternalEventRaisedInsideOfDownstreamScope.sct
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_GhsaAA9DEem0DfyI9nE3pA" specification="@CycleBased(100)&#xA;internal:&#xA;event e" name="InternalEventRaisedOutOfScope">
+    <regions xmi:id="_GhtoIw9DEem0DfyI9nE3pA" name="inside of downstream scope">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_GhzuwQ9DEem0DfyI9nE3pA">
+        <outgoingTransitions xmi:id="_nLYpAA9DEem0DfyI9nE3pA" specification="" target="_k89CkA9DEem0DfyI9nE3pA"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_k89CkA9DEem0DfyI9nE3pA" name="A" incomingTransitions="_nLYpAA9DEem0DfyI9nE3pA">
+        <regions xmi:id="_k8-QsQ9DEem0DfyI9nE3pA" name="r2">
+          <vertices xsi:type="sgraph:Entry" xmi:id="_rk1VgA9DEem0DfyI9nE3pA">
+            <outgoingTransitions xmi:id="_xgbKMA9DEem0DfyI9nE3pA" specification="" target="_s5gCYA9DEem0DfyI9nE3pA"/>
+          </vertices>
+          <vertices xsi:type="sgraph:State" xmi:id="_s5gCYA9DEem0DfyI9nE3pA" specification="entry/raise e" name="producer" incomingTransitions="_xgbKMA9DEem0DfyI9nE3pA"/>
+        </regions>
+        <regions xmi:id="_k8-QsA9DEem0DfyI9nE3pA" name="r1">
+          <vertices xsi:type="sgraph:Entry" xmi:id="_q9g20A9DEem0DfyI9nE3pA">
+            <outgoingTransitions xmi:id="_zIvL0A9DEem0DfyI9nE3pA" specification="" target="_veDCwA9DEem0DfyI9nE3pA"/>
+          </vertices>
+          <vertices xsi:type="sgraph:State" xmi:id="_veDCwA9DEem0DfyI9nE3pA" name="consumer" incomingTransitions="_zIvL0A9DEem0DfyI9nE3pA _5D8mAA9DEem0DfyI9nE3pA">
+            <outgoingTransitions xmi:id="_5D8mAA9DEem0DfyI9nE3pA" specification="e" target="_veDCwA9DEem0DfyI9nE3pA"/>
+          </vertices>
+        </regions>
+      </vertices>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_GhtoIA9DEem0DfyI9nE3pA" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_GhsaAA9DEem0DfyI9nE3pA" measurementUnit="Pixel">
+    <children xmi:id="_GhwEYA9DEem0DfyI9nE3pA" type="Region" element="_GhtoIw9DEem0DfyI9nE3pA">
+      <children xsi:type="notation:DecorationNode" xmi:id="_GhygoA9DEem0DfyI9nE3pA" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_GhygoQ9DEem0DfyI9nE3pA"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_Ghygog9DEem0DfyI9nE3pA"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_Ghygow9DEem0DfyI9nE3pA" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_Ghzuwg9DEem0DfyI9nE3pA" type="Entry" element="_GhzuwQ9DEem0DfyI9nE3pA">
+          <children xmi:id="_Gh0V0A9DEem0DfyI9nE3pA" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_Gh084A9DEem0DfyI9nE3pA" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_Gh084Q9DEem0DfyI9nE3pA"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_Gh084g9DEem0DfyI9nE3pA"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_Gh0V0Q9DEem0DfyI9nE3pA" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Gh0V0g9DEem0DfyI9nE3pA"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_Ghzuww9DEem0DfyI9nE3pA" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_GhzuxA9DEem0DfyI9nE3pA" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Gh084w9DEem0DfyI9nE3pA" x="37" y="19" width="15" height="15"/>
+        </children>
+        <children xmi:id="_k8_e0A9DEem0DfyI9nE3pA" type="State" element="_k89CkA9DEem0DfyI9nE3pA">
+          <children xsi:type="notation:DecorationNode" xmi:id="_k9As8A9DEem0DfyI9nE3pA" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_k9As8Q9DEem0DfyI9nE3pA"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_k9As8g9DEem0DfyI9nE3pA"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_k9As8w9DEem0DfyI9nE3pA" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_k9As9A9DEem0DfyI9nE3pA" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_k9As9Q9DEem0DfyI9nE3pA"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_k9BUAA9DEem0DfyI9nE3pA" type="StateFigureCompartment">
+            <children xmi:id="_OGUzoA9EEem0DfyI9nE3pA" type="Region" element="_k8-QsQ9DEem0DfyI9nE3pA">
+              <children xsi:type="notation:DecorationNode" xmi:id="_OGUzoQ9EEem0DfyI9nE3pA" type="RegionName">
+                <styles xsi:type="notation:ShapeStyle" xmi:id="_OGUzog9EEem0DfyI9nE3pA"/>
+                <layoutConstraint xsi:type="notation:Location" xmi:id="_OGUzow9EEem0DfyI9nE3pA"/>
+              </children>
+              <children xsi:type="notation:Shape" xmi:id="_OGUzpA9EEem0DfyI9nE3pA" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+                <children xmi:id="_OGUzpQ9EEem0DfyI9nE3pA" type="Entry" element="_rk1VgA9DEem0DfyI9nE3pA">
+                  <children xmi:id="_OGUzpg9EEem0DfyI9nE3pA" type="BorderItemLabelContainer">
+                    <children xsi:type="notation:DecorationNode" xmi:id="_OGUzpw9EEem0DfyI9nE3pA" type="BorderItemLabel">
+                      <styles xsi:type="notation:ShapeStyle" xmi:id="_OGUzqA9EEem0DfyI9nE3pA"/>
+                      <layoutConstraint xsi:type="notation:Location" xmi:id="_OGUzqQ9EEem0DfyI9nE3pA"/>
+                    </children>
+                    <styles xsi:type="notation:ShapeStyle" xmi:id="_OGUzqg9EEem0DfyI9nE3pA" fontName="Verdana" lineColor="4210752"/>
+                    <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OGUzqw9EEem0DfyI9nE3pA"/>
+                  </children>
+                  <styles xsi:type="notation:ShapeStyle" xmi:id="_OGUzrA9EEem0DfyI9nE3pA" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+                  <styles xsi:type="notation:NamedStyle" xmi:id="_OGUzrQ9EEem0DfyI9nE3pA" name="allowColors"/>
+                  <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OGUzrg9EEem0DfyI9nE3pA" x="5" y="2"/>
+                </children>
+                <children xmi:id="_OGUzrw9EEem0DfyI9nE3pA" type="State" element="_s5gCYA9DEem0DfyI9nE3pA">
+                  <children xsi:type="notation:DecorationNode" xmi:id="_OGUzsA9EEem0DfyI9nE3pA" type="StateName">
+                    <styles xsi:type="notation:ShapeStyle" xmi:id="_OGUzsQ9EEem0DfyI9nE3pA"/>
+                    <layoutConstraint xsi:type="notation:Location" xmi:id="_OGUzsg9EEem0DfyI9nE3pA"/>
+                  </children>
+                  <children xsi:type="notation:Compartment" xmi:id="_OGUzsw9EEem0DfyI9nE3pA" type="StateTextCompartment">
+                    <children xsi:type="notation:Shape" xmi:id="_OGUztA9EEem0DfyI9nE3pA" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+                      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OGUztQ9EEem0DfyI9nE3pA"/>
+                    </children>
+                  </children>
+                  <children xsi:type="notation:Compartment" xmi:id="_OGUztg9EEem0DfyI9nE3pA" type="StateFigureCompartment"/>
+                  <styles xsi:type="notation:ShapeStyle" xmi:id="_OGUztw9EEem0DfyI9nE3pA" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+                  <styles xsi:type="notation:FontStyle" xmi:id="_OGUzuA9EEem0DfyI9nE3pA"/>
+                  <styles xsi:type="notation:BooleanValueStyle" xmi:id="_OGUzuQ9EEem0DfyI9nE3pA" name="isHorizontal" booleanValue="true"/>
+                  <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OGUzug9EEem0DfyI9nE3pA" x="44" y="-14"/>
+                </children>
+                <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OGUzuw9EEem0DfyI9nE3pA"/>
+              </children>
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_OGUzvA9EEem0DfyI9nE3pA" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OGUzvQ9EEem0DfyI9nE3pA" x="36" y="540"/>
+            </children>
+            <children xmi:id="_RGMeEA9EEem0DfyI9nE3pA" type="Region" element="_k8-QsA9DEem0DfyI9nE3pA">
+              <children xsi:type="notation:DecorationNode" xmi:id="_RGMeEQ9EEem0DfyI9nE3pA" type="RegionName">
+                <styles xsi:type="notation:ShapeStyle" xmi:id="_RGMeEg9EEem0DfyI9nE3pA"/>
+                <layoutConstraint xsi:type="notation:Location" xmi:id="_RGMeEw9EEem0DfyI9nE3pA"/>
+              </children>
+              <children xsi:type="notation:Shape" xmi:id="_RGMeFA9EEem0DfyI9nE3pA" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+                <children xmi:id="_RGMeFQ9EEem0DfyI9nE3pA" type="Entry" element="_q9g20A9DEem0DfyI9nE3pA">
+                  <children xmi:id="_RGMeFg9EEem0DfyI9nE3pA" type="BorderItemLabelContainer">
+                    <children xsi:type="notation:DecorationNode" xmi:id="_RGMeFw9EEem0DfyI9nE3pA" type="BorderItemLabel">
+                      <styles xsi:type="notation:ShapeStyle" xmi:id="_RGMeGA9EEem0DfyI9nE3pA"/>
+                      <layoutConstraint xsi:type="notation:Location" xmi:id="_RGMeGQ9EEem0DfyI9nE3pA"/>
+                    </children>
+                    <styles xsi:type="notation:ShapeStyle" xmi:id="_RGMeGg9EEem0DfyI9nE3pA" fontName="Verdana" lineColor="4210752"/>
+                    <layoutConstraint xsi:type="notation:Bounds" xmi:id="_RGMeGw9EEem0DfyI9nE3pA"/>
+                  </children>
+                  <styles xsi:type="notation:ShapeStyle" xmi:id="_RGMeHA9EEem0DfyI9nE3pA" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+                  <styles xsi:type="notation:NamedStyle" xmi:id="_RGMeHQ9EEem0DfyI9nE3pA" name="allowColors"/>
+                  <layoutConstraint xsi:type="notation:Bounds" xmi:id="_RGMeHg9EEem0DfyI9nE3pA" x="-4" y="2"/>
+                </children>
+                <children xmi:id="_RGMeHw9EEem0DfyI9nE3pA" type="State" element="_veDCwA9DEem0DfyI9nE3pA">
+                  <children xsi:type="notation:DecorationNode" xmi:id="_RGMeIA9EEem0DfyI9nE3pA" type="StateName">
+                    <styles xsi:type="notation:ShapeStyle" xmi:id="_RGMeIQ9EEem0DfyI9nE3pA"/>
+                    <layoutConstraint xsi:type="notation:Location" xmi:id="_RGMeIg9EEem0DfyI9nE3pA"/>
+                  </children>
+                  <children xsi:type="notation:Compartment" xmi:id="_RGMeIw9EEem0DfyI9nE3pA" type="StateTextCompartment">
+                    <children xsi:type="notation:Shape" xmi:id="_RGMeJA9EEem0DfyI9nE3pA" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+                      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_RGMeJQ9EEem0DfyI9nE3pA"/>
+                    </children>
+                  </children>
+                  <children xsi:type="notation:Compartment" xmi:id="_RGMeJg9EEem0DfyI9nE3pA" type="StateFigureCompartment"/>
+                  <styles xsi:type="notation:ShapeStyle" xmi:id="_RGMeJw9EEem0DfyI9nE3pA" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+                  <styles xsi:type="notation:FontStyle" xmi:id="_RGMeKA9EEem0DfyI9nE3pA"/>
+                  <styles xsi:type="notation:BooleanValueStyle" xmi:id="_RGMeKQ9EEem0DfyI9nE3pA" name="isHorizontal" booleanValue="true"/>
+                  <layoutConstraint xsi:type="notation:Bounds" xmi:id="_RGMeKg9EEem0DfyI9nE3pA" x="27" y="2"/>
+                </children>
+                <layoutConstraint xsi:type="notation:Bounds" xmi:id="_RGMeKw9EEem0DfyI9nE3pA"/>
+              </children>
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_RGMeLA9EEem0DfyI9nE3pA" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_RGMeLQ9EEem0DfyI9nE3pA" x="228" y="492"/>
+            </children>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_k8_e0Q9DEem0DfyI9nE3pA" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_k8_e0g9DEem0DfyI9nE3pA"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_k9BUAQ9DEem0DfyI9nE3pA" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_k8_e0w9DEem0DfyI9nE3pA" x="37" y="67" width="330" height="165"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_GhygpA9DEem0DfyI9nE3pA"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_GhwEYQ9DEem0DfyI9nE3pA" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_GhzuwA9DEem0DfyI9nE3pA" x="12" y="24" width="445" height="313"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_Gh4nQA9DEem0DfyI9nE3pA" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_Gh4nQg9DEem0DfyI9nE3pA" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_Gh4nQw9DEem0DfyI9nE3pA"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_Gh4nRA9DEem0DfyI9nE3pA"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_Gh4nRQ9DEem0DfyI9nE3pA" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Gh4nRg9DEem0DfyI9nE3pA"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Gh5OUA9DEem0DfyI9nE3pA" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_GhtoIQ9DEem0DfyI9nE3pA" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_GhtoIg9DEem0DfyI9nE3pA"/>
+    <edges xmi:id="_nLaeMA9DEem0DfyI9nE3pA" type="Transition" element="_nLYpAA9DEem0DfyI9nE3pA" source="_Ghzuwg9DEem0DfyI9nE3pA" target="_k8_e0A9DEem0DfyI9nE3pA">
+      <children xsi:type="notation:DecorationNode" xmi:id="_nLbFQA9DEem0DfyI9nE3pA" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_nLbFQQ9DEem0DfyI9nE3pA"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_nLbFQg9DEem0DfyI9nE3pA" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_nLaeMQ9DEem0DfyI9nE3pA" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_nLaeMw9DEem0DfyI9nE3pA" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nLaeMg9DEem0DfyI9nE3pA" points="[7, 12, 1, -57]$[7, 47, 1, -22]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nLevoA9DEem0DfyI9nE3pA" id="(0.13333333333333333,0.06666666666666667)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nLevoQ9DEem0DfyI9nE3pA" id="(0.0268370607028754,0.1437670609645132)"/>
+    </edges>
+    <edges xmi:id="_xgc_YA9DEem0DfyI9nE3pA" type="Transition" element="_xgbKMA9DEem0DfyI9nE3pA" source="_OGUzpQ9EEem0DfyI9nE3pA" target="_OGUzrw9EEem0DfyI9nE3pA">
+      <children xsi:type="notation:DecorationNode" xmi:id="_xgc_ZA9DEem0DfyI9nE3pA" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_xgc_ZQ9DEem0DfyI9nE3pA"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_xgc_Zg9DEem0DfyI9nE3pA" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_xgc_YQ9DEem0DfyI9nE3pA" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_xgc_Yw9DEem0DfyI9nE3pA" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_xgc_Yg9DEem0DfyI9nE3pA" points="[5, 1, -56, -17]$[63, 8, 2, -10]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_xge0kA9DEem0DfyI9nE3pA" id="(0.5333333333333333,0.06666666666666667)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_xge0kQ9DEem0DfyI9nE3pA" id="(0.3013698630136986,0.22641509433962267)"/>
+    </edges>
+    <edges xmi:id="_zIwZ8A9DEem0DfyI9nE3pA" type="Transition" element="_zIvL0A9DEem0DfyI9nE3pA" source="_RGMeFQ9EEem0DfyI9nE3pA" target="_RGMeHw9EEem0DfyI9nE3pA">
+      <children xsi:type="notation:DecorationNode" xmi:id="_zIwZ9A9DEem0DfyI9nE3pA" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_zIwZ9Q9DEem0DfyI9nE3pA"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_zIwZ9g9DEem0DfyI9nE3pA" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_zIwZ8Q9DEem0DfyI9nE3pA" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_zIwZ8w9DEem0DfyI9nE3pA" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_zIwZ8g9DEem0DfyI9nE3pA" points="[7, 9, -16, -24]$[25, 23, 2, -10]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_zIyPIA9DEem0DfyI9nE3pA" id="(0.0,0.26666666666666666)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_zIyPIQ9DEem0DfyI9nE3pA" id="(0.23076923076923078,0.22641509433962267)"/>
+    </edges>
+    <edges xmi:id="_5D_pUA9DEem0DfyI9nE3pA" type="Transition" element="_5D8mAA9DEem0DfyI9nE3pA" source="_RGMeHw9EEem0DfyI9nE3pA" target="_RGMeHw9EEem0DfyI9nE3pA">
+      <children xsi:type="notation:DecorationNode" xmi:id="_5EAQYA9DEem0DfyI9nE3pA" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_5EAQYQ9DEem0DfyI9nE3pA"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_5EAQYg9DEem0DfyI9nE3pA" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_5D_pUQ9DEem0DfyI9nE3pA" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_5D_pUw9DEem0DfyI9nE3pA" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5D_pUg9DEem0DfyI9nE3pA" points="[-24, 24, -24, 24]$[-24, 36, -24, 36]$[23, 36, 23, 36]$[23, 24, 23, 24]"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.test.models/testmodels/validation/InternalEventRaisedOutsideOfDownstreamScope.sct
+++ b/test-plugins/org.yakindu.sct.test.models/testmodels/validation/InternalEventRaisedOutsideOfDownstreamScope.sct
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_GhsaAA9DEem0DfyI9nE3pA" specification="@CycleBased(100)&#xA;internal:&#xA;event e" name="InternalEventRaisedOutOfScope">
+    <regions xmi:id="_GhtoIw9DEem0DfyI9nE3pA" name="outside of downstream scope">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_GhzuwQ9DEem0DfyI9nE3pA">
+        <outgoingTransitions xmi:id="_nLYpAA9DEem0DfyI9nE3pA" specification="" target="_k89CkA9DEem0DfyI9nE3pA"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_k89CkA9DEem0DfyI9nE3pA" name="A" incomingTransitions="_nLYpAA9DEem0DfyI9nE3pA">
+        <regions xmi:id="_k8-QsA9DEem0DfyI9nE3pA" name="r1">
+          <vertices xsi:type="sgraph:Entry" xmi:id="_q9g20A9DEem0DfyI9nE3pA">
+            <outgoingTransitions xmi:id="_zIvL0A9DEem0DfyI9nE3pA" specification="" target="_veDCwA9DEem0DfyI9nE3pA"/>
+          </vertices>
+          <vertices xsi:type="sgraph:State" xmi:id="_veDCwA9DEem0DfyI9nE3pA" name="consumer" incomingTransitions="_zIvL0A9DEem0DfyI9nE3pA _5D8mAA9DEem0DfyI9nE3pA">
+            <outgoingTransitions xmi:id="_5D8mAA9DEem0DfyI9nE3pA" specification="e" target="_veDCwA9DEem0DfyI9nE3pA"/>
+          </vertices>
+        </regions>
+        <regions xmi:id="_k8-QsQ9DEem0DfyI9nE3pA" name="r2">
+          <vertices xsi:type="sgraph:Entry" xmi:id="_rk1VgA9DEem0DfyI9nE3pA">
+            <outgoingTransitions xmi:id="_xgbKMA9DEem0DfyI9nE3pA" specification="" target="_s5gCYA9DEem0DfyI9nE3pA"/>
+          </vertices>
+          <vertices xsi:type="sgraph:State" xmi:id="_s5gCYA9DEem0DfyI9nE3pA" specification="entry/raise e" name="producer" incomingTransitions="_xgbKMA9DEem0DfyI9nE3pA"/>
+        </regions>
+      </vertices>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_GhtoIA9DEem0DfyI9nE3pA" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_GhsaAA9DEem0DfyI9nE3pA" measurementUnit="Pixel">
+    <children xmi:id="_GhwEYA9DEem0DfyI9nE3pA" type="Region" element="_GhtoIw9DEem0DfyI9nE3pA">
+      <children xsi:type="notation:DecorationNode" xmi:id="_GhygoA9DEem0DfyI9nE3pA" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_GhygoQ9DEem0DfyI9nE3pA"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_Ghygog9DEem0DfyI9nE3pA"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_Ghygow9DEem0DfyI9nE3pA" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_Ghzuwg9DEem0DfyI9nE3pA" type="Entry" element="_GhzuwQ9DEem0DfyI9nE3pA">
+          <children xmi:id="_Gh0V0A9DEem0DfyI9nE3pA" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_Gh084A9DEem0DfyI9nE3pA" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_Gh084Q9DEem0DfyI9nE3pA"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_Gh084g9DEem0DfyI9nE3pA"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_Gh0V0Q9DEem0DfyI9nE3pA" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Gh0V0g9DEem0DfyI9nE3pA"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_Ghzuww9DEem0DfyI9nE3pA" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_GhzuxA9DEem0DfyI9nE3pA" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Gh084w9DEem0DfyI9nE3pA" x="37" y="19" width="15" height="15"/>
+        </children>
+        <children xmi:id="_k8_e0A9DEem0DfyI9nE3pA" type="State" element="_k89CkA9DEem0DfyI9nE3pA">
+          <children xsi:type="notation:DecorationNode" xmi:id="_k9As8A9DEem0DfyI9nE3pA" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_k9As8Q9DEem0DfyI9nE3pA"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_k9As8g9DEem0DfyI9nE3pA"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_k9As8w9DEem0DfyI9nE3pA" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_k9As9A9DEem0DfyI9nE3pA" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_k9As9Q9DEem0DfyI9nE3pA"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_k9BUAA9DEem0DfyI9nE3pA" type="StateFigureCompartment">
+            <children xmi:id="_k9HaoA9DEem0DfyI9nE3pA" type="Region" element="_k8-QsA9DEem0DfyI9nE3pA">
+              <children xsi:type="notation:DecorationNode" xmi:id="_k9IBsA9DEem0DfyI9nE3pA" type="RegionName">
+                <styles xsi:type="notation:ShapeStyle" xmi:id="_k9IBsQ9DEem0DfyI9nE3pA"/>
+                <layoutConstraint xsi:type="notation:Location" xmi:id="_k9IBsg9DEem0DfyI9nE3pA"/>
+              </children>
+              <children xsi:type="notation:Shape" xmi:id="_k9IBsw9DEem0DfyI9nE3pA" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+                <children xmi:id="_q9iE8A9DEem0DfyI9nE3pA" type="Entry" element="_q9g20A9DEem0DfyI9nE3pA">
+                  <children xmi:id="_q9isAA9DEem0DfyI9nE3pA" type="BorderItemLabelContainer">
+                    <children xsi:type="notation:DecorationNode" xmi:id="_q9jTEA9DEem0DfyI9nE3pA" type="BorderItemLabel">
+                      <styles xsi:type="notation:ShapeStyle" xmi:id="_q9jTEQ9DEem0DfyI9nE3pA"/>
+                      <layoutConstraint xsi:type="notation:Location" xmi:id="_q9jTEg9DEem0DfyI9nE3pA"/>
+                    </children>
+                    <styles xsi:type="notation:ShapeStyle" xmi:id="_q9isAQ9DEem0DfyI9nE3pA" fontName="Verdana" lineColor="4210752"/>
+                    <layoutConstraint xsi:type="notation:Bounds" xmi:id="_q9isAg9DEem0DfyI9nE3pA"/>
+                  </children>
+                  <styles xsi:type="notation:ShapeStyle" xmi:id="_q9iE8Q9DEem0DfyI9nE3pA" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+                  <styles xsi:type="notation:NamedStyle" xmi:id="_q9iE8g9DEem0DfyI9nE3pA" name="allowColors"/>
+                  <layoutConstraint xsi:type="notation:Bounds" xmi:id="_q9iE8w9DEem0DfyI9nE3pA" x="-4" y="2"/>
+                </children>
+                <children xmi:id="_veGtIA9DEem0DfyI9nE3pA" type="State" element="_veDCwA9DEem0DfyI9nE3pA">
+                  <children xsi:type="notation:DecorationNode" xmi:id="_veHUMA9DEem0DfyI9nE3pA" type="StateName">
+                    <styles xsi:type="notation:ShapeStyle" xmi:id="_veHUMQ9DEem0DfyI9nE3pA"/>
+                    <layoutConstraint xsi:type="notation:Location" xmi:id="_veHUMg9DEem0DfyI9nE3pA"/>
+                  </children>
+                  <children xsi:type="notation:Compartment" xmi:id="_veHUMw9DEem0DfyI9nE3pA" type="StateTextCompartment">
+                    <children xsi:type="notation:Shape" xmi:id="_veHUNA9DEem0DfyI9nE3pA" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+                      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_veHUNQ9DEem0DfyI9nE3pA"/>
+                    </children>
+                  </children>
+                  <children xsi:type="notation:Compartment" xmi:id="_veHUNg9DEem0DfyI9nE3pA" type="StateFigureCompartment"/>
+                  <styles xsi:type="notation:ShapeStyle" xmi:id="_veGtIQ9DEem0DfyI9nE3pA" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+                  <styles xsi:type="notation:FontStyle" xmi:id="_veGtIg9DEem0DfyI9nE3pA"/>
+                  <styles xsi:type="notation:BooleanValueStyle" xmi:id="_veH7QA9DEem0DfyI9nE3pA" name="isHorizontal" booleanValue="true"/>
+                  <layoutConstraint xsi:type="notation:Bounds" xmi:id="_veGtIw9DEem0DfyI9nE3pA" x="27" y="2"/>
+                </children>
+                <layoutConstraint xsi:type="notation:Bounds" xmi:id="_k9IBtA9DEem0DfyI9nE3pA"/>
+              </children>
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_k9HaoQ9DEem0DfyI9nE3pA" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_k9Haog9DEem0DfyI9nE3pA"/>
+            </children>
+            <children xmi:id="_1cpIIA9DEem0DfyI9nE3pA" type="Region" element="_k8-QsQ9DEem0DfyI9nE3pA">
+              <children xsi:type="notation:DecorationNode" xmi:id="_1cpIIQ9DEem0DfyI9nE3pA" type="RegionName">
+                <styles xsi:type="notation:ShapeStyle" xmi:id="_1cpIIg9DEem0DfyI9nE3pA"/>
+                <layoutConstraint xsi:type="notation:Location" xmi:id="_1cpIIw9DEem0DfyI9nE3pA"/>
+              </children>
+              <children xsi:type="notation:Shape" xmi:id="_1cpIJA9DEem0DfyI9nE3pA" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+                <children xmi:id="_1cpIJQ9DEem0DfyI9nE3pA" type="Entry" element="_rk1VgA9DEem0DfyI9nE3pA">
+                  <children xmi:id="_1cpIJg9DEem0DfyI9nE3pA" type="BorderItemLabelContainer">
+                    <children xsi:type="notation:DecorationNode" xmi:id="_1cpIJw9DEem0DfyI9nE3pA" type="BorderItemLabel">
+                      <styles xsi:type="notation:ShapeStyle" xmi:id="_1cpIKA9DEem0DfyI9nE3pA"/>
+                      <layoutConstraint xsi:type="notation:Location" xmi:id="_1cpIKQ9DEem0DfyI9nE3pA"/>
+                    </children>
+                    <styles xsi:type="notation:ShapeStyle" xmi:id="_1cpIKg9DEem0DfyI9nE3pA" fontName="Verdana" lineColor="4210752"/>
+                    <layoutConstraint xsi:type="notation:Bounds" xmi:id="_1cpIKw9DEem0DfyI9nE3pA"/>
+                  </children>
+                  <styles xsi:type="notation:ShapeStyle" xmi:id="_1cpILA9DEem0DfyI9nE3pA" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+                  <styles xsi:type="notation:NamedStyle" xmi:id="_1cpILQ9DEem0DfyI9nE3pA" name="allowColors"/>
+                  <layoutConstraint xsi:type="notation:Bounds" xmi:id="_1cpILg9DEem0DfyI9nE3pA" x="5" y="2"/>
+                </children>
+                <children xmi:id="_1cpILw9DEem0DfyI9nE3pA" type="State" element="_s5gCYA9DEem0DfyI9nE3pA">
+                  <children xsi:type="notation:DecorationNode" xmi:id="_1cpIMA9DEem0DfyI9nE3pA" type="StateName">
+                    <styles xsi:type="notation:ShapeStyle" xmi:id="_1cpIMQ9DEem0DfyI9nE3pA"/>
+                    <layoutConstraint xsi:type="notation:Location" xmi:id="_1cpIMg9DEem0DfyI9nE3pA"/>
+                  </children>
+                  <children xsi:type="notation:Compartment" xmi:id="_1cpIMw9DEem0DfyI9nE3pA" type="StateTextCompartment">
+                    <children xsi:type="notation:Shape" xmi:id="_1cpINA9DEem0DfyI9nE3pA" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+                      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_1cpINQ9DEem0DfyI9nE3pA"/>
+                    </children>
+                  </children>
+                  <children xsi:type="notation:Compartment" xmi:id="_1cpINg9DEem0DfyI9nE3pA" type="StateFigureCompartment"/>
+                  <styles xsi:type="notation:ShapeStyle" xmi:id="_1cpINw9DEem0DfyI9nE3pA" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+                  <styles xsi:type="notation:FontStyle" xmi:id="_1cpIOA9DEem0DfyI9nE3pA"/>
+                  <styles xsi:type="notation:BooleanValueStyle" xmi:id="_1cpIOQ9DEem0DfyI9nE3pA" name="isHorizontal" booleanValue="true"/>
+                  <layoutConstraint xsi:type="notation:Bounds" xmi:id="_1cpIOg9DEem0DfyI9nE3pA" x="44" y="-14"/>
+                </children>
+                <layoutConstraint xsi:type="notation:Bounds" xmi:id="_1cpIOw9DEem0DfyI9nE3pA"/>
+              </children>
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_1cpIPA9DEem0DfyI9nE3pA" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_1cpIPQ9DEem0DfyI9nE3pA"/>
+            </children>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_k8_e0Q9DEem0DfyI9nE3pA" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_k8_e0g9DEem0DfyI9nE3pA"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_k9BUAQ9DEem0DfyI9nE3pA" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_k8_e0w9DEem0DfyI9nE3pA" x="37" y="67" width="330" height="165"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_GhygpA9DEem0DfyI9nE3pA"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_GhwEYQ9DEem0DfyI9nE3pA" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_GhzuwA9DEem0DfyI9nE3pA" x="12" y="24" width="409" height="301"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_Gh4nQA9DEem0DfyI9nE3pA" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_Gh4nQg9DEem0DfyI9nE3pA" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_Gh4nQw9DEem0DfyI9nE3pA"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_Gh4nRA9DEem0DfyI9nE3pA"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_Gh4nRQ9DEem0DfyI9nE3pA" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Gh4nRg9DEem0DfyI9nE3pA"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Gh5OUA9DEem0DfyI9nE3pA" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_GhtoIQ9DEem0DfyI9nE3pA" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_GhtoIg9DEem0DfyI9nE3pA"/>
+    <edges xmi:id="_nLaeMA9DEem0DfyI9nE3pA" type="Transition" element="_nLYpAA9DEem0DfyI9nE3pA" source="_Ghzuwg9DEem0DfyI9nE3pA" target="_k8_e0A9DEem0DfyI9nE3pA">
+      <children xsi:type="notation:DecorationNode" xmi:id="_nLbFQA9DEem0DfyI9nE3pA" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_nLbFQQ9DEem0DfyI9nE3pA"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_nLbFQg9DEem0DfyI9nE3pA" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_nLaeMQ9DEem0DfyI9nE3pA" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_nLaeMw9DEem0DfyI9nE3pA" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nLaeMg9DEem0DfyI9nE3pA" points="[7, 12, 1, -57]$[7, 47, 1, -22]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nLevoA9DEem0DfyI9nE3pA" id="(0.13333333333333333,0.06666666666666667)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nLevoQ9DEem0DfyI9nE3pA" id="(0.0268370607028754,0.1437670609645132)"/>
+    </edges>
+    <edges xmi:id="_xgc_YA9DEem0DfyI9nE3pA" type="Transition" element="_xgbKMA9DEem0DfyI9nE3pA" source="_1cpIJQ9DEem0DfyI9nE3pA" target="_1cpILw9DEem0DfyI9nE3pA">
+      <children xsi:type="notation:DecorationNode" xmi:id="_xgc_ZA9DEem0DfyI9nE3pA" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_xgc_ZQ9DEem0DfyI9nE3pA"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_xgc_Zg9DEem0DfyI9nE3pA" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_xgc_YQ9DEem0DfyI9nE3pA" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_xgc_Yw9DEem0DfyI9nE3pA" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_xgc_Yg9DEem0DfyI9nE3pA" points="[5, 1, -56, -17]$[63, 8, 2, -10]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_xge0kA9DEem0DfyI9nE3pA" id="(0.5333333333333333,0.06666666666666667)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_xge0kQ9DEem0DfyI9nE3pA" id="(0.3013698630136986,0.22641509433962267)"/>
+    </edges>
+    <edges xmi:id="_zIwZ8A9DEem0DfyI9nE3pA" type="Transition" element="_zIvL0A9DEem0DfyI9nE3pA" source="_q9iE8A9DEem0DfyI9nE3pA" target="_veGtIA9DEem0DfyI9nE3pA">
+      <children xsi:type="notation:DecorationNode" xmi:id="_zIwZ9A9DEem0DfyI9nE3pA" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_zIwZ9Q9DEem0DfyI9nE3pA"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_zIwZ9g9DEem0DfyI9nE3pA" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_zIwZ8Q9DEem0DfyI9nE3pA" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_zIwZ8w9DEem0DfyI9nE3pA" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_zIwZ8g9DEem0DfyI9nE3pA" points="[7, 9, -16, -24]$[25, 23, 2, -10]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_zIyPIA9DEem0DfyI9nE3pA" id="(0.0,0.26666666666666666)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_zIyPIQ9DEem0DfyI9nE3pA" id="(0.23076923076923078,0.22641509433962267)"/>
+    </edges>
+    <edges xmi:id="_5D_pUA9DEem0DfyI9nE3pA" type="Transition" element="_5D8mAA9DEem0DfyI9nE3pA" source="_veGtIA9DEem0DfyI9nE3pA" target="_veGtIA9DEem0DfyI9nE3pA">
+      <children xsi:type="notation:DecorationNode" xmi:id="_5EAQYA9DEem0DfyI9nE3pA" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_5EAQYQ9DEem0DfyI9nE3pA"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_5EAQYg9DEem0DfyI9nE3pA" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_5D_pUQ9DEem0DfyI9nE3pA" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_5D_pUw9DEem0DfyI9nE3pA" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5D_pUg9DEem0DfyI9nE3pA" points="[-24, 24, -24, 24]$[-24, 36, -24, 36]$[23, 36, 23, 36]$[23, 24, 23, 24]"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>


### PR DESCRIPTION
when i start SCT Pro using this branch, i get errors when some sct file is opened. @axel has not found an easy solution for this, said he would have to dig deeper in the module structure.

Can someone look at this and tell me why these errors are thrown? @andreasmuelder maybe?

ref  #2435

```
!MESSAGE Unable to create part
!SUBENTRY 1 org.eclipse.ui 4 0 2019-01-06 15:03:31.136
!MESSAGE com.google.inject.CreationException: Guice creation errors:

1) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=languageName) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=languageName)
    for parameter 0 at org.eclipse.xtext.LanguageInfo.<init>(Unknown Source)
  while locating org.eclipse.xtext.LanguageInfo
    for field at org.eclipse.xtext.preferences.IPreferenceValuesProvider$DefaultPreferenceValuesProvider.language(Unknown Source)
  while locating org.eclipse.xtext.preferences.IPreferenceValuesProvider
    for field at org.eclipse.xtext.validation.IssueSeveritiesProvider.valuesProvider(Unknown Source)
  while locating org.eclipse.xtext.validation.IssueSeveritiesProvider
    for field at org.eclipse.xtext.validation.AbstractDeclarativeValidator.issueSeveritiesProvider(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

2) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=languageName) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=languageName)
    for parameter 0 at org.eclipse.xtext.service.GrammarProvider.<init>(Unknown Source)
  while locating org.eclipse.xtext.service.GrammarProvider
    for parameter 0 at org.yakindu.sct.model.stext.services.STextGrammarAccess.<init>(Unknown Source)
  while locating org.yakindu.sct.model.stext.services.STextGrammarAccess
    for field at org.yakindu.sct.model.stext.validation.STextValidator.grammarAccess(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

3) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=languageName) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=languageName)
    for parameter 0 at org.eclipse.xtext.service.GrammarProvider.<init>(Unknown Source)
  while locating org.eclipse.xtext.service.GrammarProvider
    for parameter 0 at org.yakindu.base.expressions.services.ExpressionsGrammarAccess.<init>(Unknown Source)
  while locating org.yakindu.base.expressions.services.ExpressionsGrammarAccess
    for parameter 1 at org.yakindu.sct.model.stext.services.STextGrammarAccess.<init>(Unknown Source)
  while locating org.yakindu.sct.model.stext.services.STextGrammarAccess
    for field at org.yakindu.sct.model.stext.validation.STextValidator.grammarAccess(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

4) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=languageName) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=languageName)
    for parameter 0 at org.eclipse.xtext.service.GrammarProvider.<init>(Unknown Source)
  while locating org.eclipse.xtext.service.GrammarProvider
    for parameter 0 at org.eclipse.xtext.common.services.TerminalsGrammarAccess.<init>(Unknown Source)
  while locating org.eclipse.xtext.common.services.TerminalsGrammarAccess
    for parameter 1 at org.yakindu.base.expressions.services.ExpressionsGrammarAccess.<init>(Unknown Source)
  while locating org.yakindu.base.expressions.services.ExpressionsGrammarAccess
    for parameter 1 at org.yakindu.sct.model.stext.services.STextGrammarAccess.<init>(Unknown Source)
  while locating org.yakindu.sct.model.stext.services.STextGrammarAccess
    for field at org.yakindu.sct.model.stext.validation.STextValidator.grammarAccess(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

5) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=languageName) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=languageName)
    for parameter 0 at org.eclipse.xtext.service.GrammarProvider.<init>(Unknown Source)
  while locating org.eclipse.xtext.service.GrammarProvider
    for parameter 0 at org.eclipse.xtext.common.services.TerminalsGrammarAccess.<init>(Unknown Source)
  while locating org.eclipse.xtext.common.services.TerminalsGrammarAccess
    for parameter 2 at org.yakindu.sct.model.stext.services.STextGrammarAccess.<init>(Unknown Source)
  while locating org.yakindu.sct.model.stext.services.STextGrammarAccess
    for field at org.yakindu.sct.model.stext.validation.STextValidator.grammarAccess(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

6) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=languageName) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=languageName)
    for field at org.eclipse.xtext.validation.AbstractInjectableValidator.languageName(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

7) No implementation for org.eclipse.emf.ecore.EValidator$Registry was bound.
  while locating org.eclipse.emf.ecore.EV
1) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=languageName) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=languageName)
    for parameter 0 at org.eclipse.xtext.LanguageInfo.<init>(Unknown Source)
  while locating org.eclipse.xtext.LanguageInfo
    for field at org.eclipse.xtext.preferences.IPreferenceValuesProvider$DefaultPreferenceValuesProvider.language(Unknown Source)
  while locating org.eclipse.xtext.preferences.IPreferenceValuesProvider
    for field at org.eclipse.xtext.validation.IssueSeveritiesProvider.valuesProvider(Unknown Source)
  while locating org.eclipse.xtext.validation.IssueSeveritiesProvider
    for field at org.eclipse.xtext.validation.AbstractDeclarativeValidator.issueSeveritiesProvider(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

2) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=languageName) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=languageName)
    for parameter 0 at org.eclipse.xtext.service.GrammarProvider.<init>(Unknown Source)
  while locating org.eclipse.xtext.service.GrammarProvider
    for parameter 0 at org.yakindu.sct.model.stext.services.STextGrammarAccess.<init>(Unknown Source)
  while locating org.yakindu.sct.model.stext.services.STextGrammarAccess
    for field at org.yakindu.sct.model.stext.validation.STextValidator.grammarAccess(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

3) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=languageName) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=languageName)
    for parameter 0 at org.eclipse.xtext.service.GrammarProvider.<init>(Unknown Source)
  while locating org.eclipse.xtext.service.GrammarProvider
    for parameter 0 at org.yakindu.base.expressions.services.ExpressionsGrammarAccess.<init>(Unknown Source)
  while locating org.yakindu.base.expressions.services.ExpressionsGrammarAccess
    for parameter 1 at org.yakindu.sct.model.stext.services.STextGrammarAccess.<init>(Unknown Source)
  while locating org.yakindu.sct.model.stext.services.STextGrammarAccess
    for field at org.yakindu.sct.model.stext.validation.STextValidator.grammarAccess(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

4) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=languageName) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=languageName)
    for parameter 0 at org.eclipse.xtext.service.GrammarProvider.<init>(Unknown Source)
  while locating org.eclipse.xtext.service.GrammarProvider
    for parameter 0 at org.eclipse.xtext.common.services.TerminalsGrammarAccess.<init>(Unknown Source)
  while locating org.eclipse.xtext.common.services.TerminalsGrammarAccess
    for parameter 1 at org.yakindu.base.expressions.services.ExpressionsGrammarAccess.<init>(Unknown Source)
  while locating org.yakindu.base.expressions.services.ExpressionsGrammarAccess
    for parameter 1 at org.yakindu.sct.model.stext.services.STextGrammarAccess.<init>(Unknown Source)
  while locating org.yakindu.sct.model.stext.services.STextGrammarAccess
    for field at org.yakindu.sct.model.stext.validation.STextValidator.grammarAccess(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

5) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=languageName) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=languageName)
    for parameter 0 at org.eclipse.xtext.service.GrammarProvider.<init>(Unknown Source)
  while locating org.eclipse.xtext.service.GrammarProvider
    for parameter 0 at org.eclipse.xtext.common.services.TerminalsGrammarAccess.<init>(Unknown Source)
  while locating org.eclipse.xtext.common.services.TerminalsGrammarAccess
    for parameter 2 at org.yakindu.sct.model.stext.services.STextGrammarAccess.<init>(Unknown Source)
  while locating org.yakindu.sct.model.stext.services.STextGrammarAccess
    for field at org.yakindu.sct.model.stext.validation.STextValidator.grammarAccess(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

6) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=languageName) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=languageName)
    for field at org.eclipse.xtext.validation.AbstractInjectableValidator.languageName(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

7) No implementation for org.eclipse.emf.ecore.EValidator$Registry was bound.
  while locating org.eclipse.emf.ecore.EValidator$Registry
    for field at org.eclipse.xtext.validation.EValidatorRegistrar.registry(Unknown Source)
  while locating org.eclipse.xtext.validation.EValidatorRegistrar
    for parameter 0 at org.eclipse.xtext.validation.AbstractInjectableValidator.register(Unknown Source)
  at org.eclipse.xtext.validation.AbstractInjectableValidator.register(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

8) No implementation for org.yakindu.base.types.inferrer.ITypeSystemInferrer was bound.
  while locating org.yakindu.base.types.inferrer.ITypeSystemInferrer
    for field at org.yakindu.base.expressions.validation.ExpressionsValidator.typeInferrer(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

9) No implementation for org.eclipse.xtext.naming.IQualifiedNameProvider was bound.
  while locating org.eclipse.xtext.naming.IQualifiedNameProvider
    for field at org.yakindu.sct.model.sexec.transformation.SexecElementMapping.qfnProvider(Unknown Source)
  while locating org.yakindu.sct.model.sexec.transformation.SexecElementMapping
    for field at org.yakindu.sct.model.sexec.validation.SExecValidator.mapping(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

10) No implementation for org.eclipse.xtext.naming.IQualifiedNameProvider was bound.
  while locating org.eclipse.xtext.naming.IQualifiedNameProvider
    for field at org.yakindu.sct.model.sexec.transformation.SexecElementMapping.qfnProvider(Unknown Source)
  while locating org.yakindu.sct.model.sexec.transformation.SexecElementMapping
    for field at org.yakindu.sct.model.sexec.transformation.StructureMapping.mapping(Unknown Source)
  while locating org.yakindu.sct.model.sexec.transformation.StructureMapping
    for field at org.yakindu.sct.model.sexec.validation.SExecValidator.structureMapping(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

11) No implementation for org.eclipse.xtext.naming.IQualifiedNameProvider was bound.
  while locating org.eclipse.xtext.naming.IQualifiedNameProvider
    for field at org.yakindu.sct.model.sexec.transformation.SexecElementMapping.qfnProvider(Unknown Source)
  while locating org.yakindu.sct.model.sexec.transformation.SexecElementMapping
    for field at org.yakindu.sct.model.sexec.transformation.StateVectorBuilder.mapping(Unknown Source)
  while locating org.yakindu.sct.model.sexec.transformation.StateVectorBuilder
    for field at org.yakindu.sct.model.sexec.validation.SExecValidator.svBuilder(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

12) No implementation for org.eclipse.xtext.naming.IQualifiedNameProvider was bound.
  while locating org.eclipse.xtext.naming.IQualifiedNameProvider
    for field at org.yakindu.sct.model.sexec.transformation.StructureMapping._iQualifiedNameProvider(Unknown Source)
  while locating org.yakindu.sct.model.sexec.transformation.StructureMapping
    for field at org.yakindu.sct.model.sexec.validation.SExecValidator.structureMapping(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

13) No implementation for org.eclipse.xtext.naming.IQualifiedNameProvider was bound.
  while locating org.eclipse.xtext.naming.IQualifiedNameProvider
    for field at org.yakindu.sct.model.stext.validation.STextValidator.nameProvider(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

14) No implementation for org.yakindu.base.types.inferrer.ITypeSystemInferrer was bound.
  while locating org.yakindu.base.types.inferrer.ITypeSystemInferrer
    for field at org.yakindu.sct.model.stext.validation.STextValidator.typeInferrer(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

14 errorsalidator$Registry
    for field at org.eclipse.xtext.validation.EValidatorRegistrar.registry(Unknown Source)
  while locating org.eclipse.xtext.validation.EValidatorRegistrar
    for parameter 0 at org.eclipse.xtext.validation.AbstractInjectableValidator.register(Unknown Source)
  at org.eclipse.xtext.validation.AbstractInjectableValidator.register(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

8) No implementation for org.yakindu.base.types.inferrer.ITypeSystemInferrer was bound.
  while locating org.yakindu.base.types.inferrer.ITypeSystemInferrer
    for field at org.yakindu.base.expressions.validation.ExpressionsValidator.typeInferrer(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

9) No implementation for org.eclipse.xtext.naming.IQualifiedNameProvider was bound.
  while locating org.eclipse.xtext.naming.IQualifiedNameProvider
    for field at org.yakindu.sct.model.sexec.transformation.SexecElementMapping.qfnProvider(Unknown Source)
  while locating org.yakindu.sct.model.sexec.transformation.SexecElementMapping
    for field at org.yakindu.sct.model.sexec.validation.SExecValidator.mapping(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

10) No implementation for org.eclipse.xtext.naming.IQualifiedNameProvider was bound.
  while locating org.eclipse.xtext.naming.IQualifiedNameProvider
    for field at org.yakindu.sct.model.sexec.transformation.SexecElementMapping.qfnProvider(Unknown Source)
  while locating org.yakindu.sct.model.sexec.transformation.SexecElementMapping
    for field at org.yakindu.sct.model.sexec.transformation.StructureMapping.mapping(Unknown Source)
  while locating org.yakindu.sct.model.sexec.transformation.StructureMapping
    for field at org.yakindu.sct.model.sexec.validation.SExecValidator.structureMapping(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

11) No implementation for org.eclipse.xtext.naming.IQualifiedNameProvider was bound.
  while locating org.eclipse.xtext.naming.IQualifiedNameProvider
    for field at org.yakindu.sct.model.sexec.transformation.SexecElementMapping.qfnProvider(Unknown Source)
  while locating org.yakindu.sct.model.sexec.transformation.SexecElementMapping
    for field at org.yakindu.sct.model.sexec.transformation.StateVectorBuilder.mapping(Unknown Source)
  while locating org.yakindu.sct.model.sexec.transformation.StateVectorBuilder
    for field at org.yakindu.sct.model.sexec.validation.SExecValidator.svBuilder(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

12) No implementation for org.eclipse.xtext.naming.IQualifiedNameProvider was bound.
  while locating org.eclipse.xtext.naming.IQualifiedNameProvider
    for field at org.yakindu.sct.model.sexec.transformation.StructureMapping._iQualifiedNameProvider(Unknown Source)
  while locating org.yakindu.sct.model.sexec.transformation.StructureMapping
    for field at org.yakindu.sct.model.sexec.validation.SExecValidator.structureMapping(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

13) No implementation for org.eclipse.xtext.naming.IQualifiedNameProvider was bound.
  while locating org.eclipse.xtext.naming.IQualifiedNameProvider
    for field at org.yakindu.sct.model.stext.validation.STextValidator.nameProvider(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

14) No implementation for org.yakindu.base.types.inferrer.ITypeSystemInferrer was bound.
  while locating org.yakindu.base.types.inferrer.ITypeSystemInferrer
    for field at org.yakindu.sct.model.stext.validation.STextValidator.typeInferrer(Unknown Source)
  at org.eclipse.xtext.service.MethodBasedModule.configure(MethodBasedModule.java:57)

14 errors
```
