### PR TITLE
Filter for null to avoid NPE when inferrer returns null for an argument

### DIFF
--- a/plugins/org.yakindu.base.expressions/src/org/yakindu/base/expressions/linking/OperationOverloadingResolver.java
+++ b/plugins/org.yakindu.base.expressions/src/org/yakindu/base/expressions/linking/OperationOverloadingResolver.java
@@ -92,8 +92,14 @@ public class OperationOverloadingResolver {
 	protected boolean isCallable(Operation operation, ArgumentExpression expression) {
 		EList<Expression> orderedExpressions = ArgumentSorter.getOrderedExpressions(expression.getArguments(),
 				operation);
-		List<Type> argumentTypes = orderedExpressions.stream().map(it -> inferrer.infer(it).getType())
-				.filter(t -> t != null).collect(Collectors.toList());
+		
+		List<Type> argumentTypes = orderedExpressions.stream()
+				.map(it -> inferrer.infer(it))
+				.filter(t -> t != null)
+				.map(t -> t.getType())
+				.filter(t -> t != null)
+				.collect(Collectors.toList());
+		
 		List<Type> parameterTypes = operation.getParameters().stream().map(it -> it.getType())
 				.collect(Collectors.toList());
 		if (argumentTypes.size() != parameterTypes.size())


### PR DESCRIPTION
This happens when the argument expression is incomplete, like a valueof without event reference, or a typecast without type reference.