### PR TITLE
Use explicit instanceof check to avoid NPE

### DIFF
--- a/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/naming/DefaultNamingService.xtend
+++ b/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/naming/DefaultNamingService.xtend
@@ -386,7 +386,7 @@ class DefaultNamingService implements INamingService {
 	}
 	
 	def protected dispatch String elementName(ExecutionEntry it) {
-		return provider.getFullyQualifiedName(it).skipFirst(1).toString(separator.toString)
+		return provider.getFullyQualifiedName(it).skipFirst(2).toString(separator.toString)
 	}
 
 	// TODO: we should merge the region/vertex case into this base implementation; we should check whether it is used in any case at all (otherwise it could be replaced with the body of vertexOrRegionName)

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/naming/SGraphNameProvider.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/naming/SGraphNameProvider.java
@@ -216,7 +216,7 @@ public class SGraphNameProvider extends DefaultDeclarativeQualifiedNameProvider 
 		QualifiedName namespace = getNamespace(ele);
 		if (ele instanceof ComplexType && namespace == null) {
 			if (ele.eContainer() instanceof ComplexType) {
-				namespace = qualifiedName(ele.eContainer());
+				namespace = qualifiedName((ComplexType) ele.eContainer());
 			}
 		}
 		if (!Strings.isEmpty(ele.getName())) {

--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/naming/SGraphNameProvider.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/naming/SGraphNameProvider.java
@@ -214,9 +214,10 @@ public class SGraphNameProvider extends DefaultDeclarativeQualifiedNameProvider 
 	public QualifiedName qualifiedName(Declaration ele) {
 		QualifiedName name = null;
 		QualifiedName namespace = getNamespace(ele);
-		if(ele instanceof ComplexType && namespace == null) {
-			ComplexType ct= (ComplexType) ele.eContainer();
-			namespace = qualifiedName(ct);
+		if (ele instanceof ComplexType && namespace == null) {
+			if (ele.eContainer() instanceof ComplexType) {
+				namespace = qualifiedName(ele.eContainer());
+			}
 		}
 		if (!Strings.isEmpty(ele.getName())) {
 			name = nameConverter.toQualifiedName(ele.getName());


### PR DESCRIPTION
Fixes #2621 

Tested with TrafficLight (Java), CoffeeMachine (C) & (CPP). All generated files could be compiled.