### PR TITLE
Search for cross references only in same statechart

### DIFF
--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextValidator.xtend
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextValidator.xtend
@@ -314,7 +314,7 @@ class STextValidator extends AbstractSTextValidator implements STextValidationMe
 		if (event.direction != Direction.OUT) {
 			return;
 		}
-		var Collection<Setting> usages = EcoreUtil.UsageCrossReferencer.find(event, event.eResource().getResourceSet());
+		var Collection<Setting> usages = EcoreUtil.UsageCrossReferencer.find(event, event.eResource());
 		var isRaised = usages.exists[setting | setting.getEObject().eContainer instanceof EventRaisingExpression]
 		if (!isRaised) {
 			usages.filter[ setting |


### PR DESCRIPTION
This improves the performance drastically because no external resources are loaded anymore, e.g. when in Java domain scenario.

Fixes #2627 