### PR TITLE
Only build all travis targets when building master or PRs against master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
 matrix:
   include:
   - env: TARGET=Neon.target
+    if: branch = master
   - env: TARGET=Oxygen.target
   - env: TARGET=Photon.target
   - env: TARGET=2018-09.target

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,12 @@ env:
   - LIBRARY_PATH=${TRAVIS_BUILD_DIR}/googletest-release-1.8.0/googletest/build:${TRAVIS_BUILD_DIR}/googletest-release-1.8.0/googlemock/build:$LIBRARY_PATH
   - CPATH=${TRAVIS_BUILD_DIR}/googletest-release-1.8.0/googletest/include:${TRAVIS_BUILD_DIR}/googletest-release-1.8.0/googlemock/include:$CPATH
   - GMOCK_HOME
-  matrix:
-  - TARGET=Neon.target
-  - TARGET=Oxygen.target
-  - TARGET=Photon.target
-  - TARGET=2018-09.target
+matrix:
+  include:
+  - env: TARGET=Neon.target
+  - env: TARGET=Oxygen.target
+  - env: TARGET=Photon.target
+  - env: TARGET=2018-09.target
 before_script:
  - wget https://github.com/google/googletest/archive/release-1.8.0.zip
  - unzip release-1.8.0.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ matrix:
   - env: TARGET=Neon.target
     if: branch = master
   - env: TARGET=Oxygen.target
+    if: branch = master
   - env: TARGET=Photon.target
+    if: branch = master
   - env: TARGET=2018-09.target
 before_script:
  - wget https://github.com/google/googletest/archive/release-1.8.0.zip


### PR DESCRIPTION
Saves build jobs & the planet. :)

Check in the travis jobs: the `push` job only builds the newest target, 2018-09, whereas the `pr` job builds all four matrix entries.

[See travis condition language for doc](https://docs.travis-ci.com/user/conditions-v1)