### PR TITLE
initial SText quickfix implementation for unknown events

### DIFF
--- a/plugins/org.yakindu.base.expressions.ui/src/org/yakindu/base/expressions/ui/quickfix/ExpressionsQuickfixProvider.xtend
+++ b/plugins/org.yakindu.base.expressions.ui/src/org/yakindu/base/expressions/ui/quickfix/ExpressionsQuickfixProvider.xtend
@@ -10,24 +10,8 @@
 */
 package org.yakindu.base.expressions.ui.quickfix
 
-//import org.eclipse.xtext.ui.editor.quickfix.Fix
-//import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionAcceptor
-//import org.eclipse.xtext.validation.Issue
+import org.eclipse.xtext.ui.editor.quickfix.DefaultQuickfixProvider
 
-/**
- * Custom quickfixes.
- *
- * see http://www.eclipse.org/Xtext/documentation.html#quickfixes
- */
-class ExpressionsQuickfixProvider extends org.eclipse.xtext.ui.editor.quickfix.DefaultQuickfixProvider {
+class ExpressionsQuickfixProvider extends DefaultQuickfixProvider {
 
-//	@Fix(MyDslValidator::INVALID_NAME)
-//	def capitalizeName(Issue issue, IssueResolutionAcceptor acceptor) {
-//		acceptor.accept(issue, 'Capitalize name', 'Capitalize the name.', 'upcase.png') [
-//			context |
-//			val xtextDocument = context.xtextDocument
-//			val firstLetter = xtextDocument.get(issue.offset, 1)
-//			xtextDocument.replace(issue.offset, 1, firstLetter.toUpperCase)
-//		]
-//	}
 }

--- a/plugins/org.yakindu.base.expressions/src/org/yakindu/base/expressions/validation/ExpressionsValidator.xtend
+++ b/plugins/org.yakindu.base.expressions/src/org/yakindu/base/expressions/validation/ExpressionsValidator.xtend
@@ -42,10 +42,6 @@ import org.yakindu.base.types.TypesPackage
 import org.yakindu.base.types.inferrer.ITypeSystemInferrer
 import org.yakindu.base.types.validation.IValidationIssueAcceptor
 import org.yakindu.base.types.validation.TypesJavaValidator
-import org.yakindu.base.expressions.expressions.EventRaisingExpression
-import org.yakindu.base.types.Event
-import org.yakindu.base.base.NamedElement
-import org.yakindu.base.expressions.util.ExpressionExtensions
 
 /** 
  * @author andreas muelder - Initial contribution and API
@@ -54,7 +50,6 @@ import org.yakindu.base.expressions.util.ExpressionExtensions
 class ExpressionsValidator extends AbstractExpressionsValidator implements IValidationIssueAcceptor {
 
 	@Inject ITypeSystemInferrer typeInferrer
-	@Inject extension ExpressionExtensions
 
 	override void accept(ValidationIssue issue) {
 		switch (issue.getSeverity()) {
@@ -282,19 +277,6 @@ class ExpressionsValidator extends AbstractExpressionsValidator implements IVali
 			annotation.getArguments().size() !== annotation.getType().getProperties().size()) {
 			error(String.format(ERROR_WRONG_NUMBER_OF_ARGUMENTS_MSG, annotation.getType().getProperties()), null,
 				ERROR_WRONG_NUMBER_OF_ARGUMENTS_CODE)
-		}
-	}
-	
-	@Check(CheckType.FAST)
-	def void checkRaisingExpressionEvent(EventRaisingExpression expression) {
-		var EObject element = expression.event.featureOrReference
-		if (element !== null && (!(element instanceof Event))) {
-			var String elementName = ""
-			if (element instanceof NamedElement) {
-				elementName = element.getName()
-			}
-			error(String.format("'%s' is not an event.", elementName),
-				ExpressionsPackage.Literals.EVENT_RAISING_EXPRESSION__EVENT, -1)
 		}
 	}
 }

--- a/plugins/org.yakindu.sct.generator.genmodel.ui/src/org/yakindu/sct/generator/genmodel/ui/quickfix/SGenQuickfixProvider.xtend
+++ b/plugins/org.yakindu.sct.generator.genmodel.ui/src/org/yakindu/sct/generator/genmodel/ui/quickfix/SGenQuickfixProvider.xtend
@@ -25,10 +25,12 @@ import org.eclipse.xtext.ui.editor.quickfix.DefaultQuickfixProvider
 import org.eclipse.xtext.ui.editor.quickfix.Fix
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionAcceptor
 import org.eclipse.xtext.validation.Issue
+import org.yakindu.sct.commons.EmfUriUtil
 import org.yakindu.sct.generator.core.extensions.GeneratorExtensions
 import org.yakindu.sct.generator.core.extensions.IGeneratorDescriptor
 import org.yakindu.sct.generator.core.extensions.ILibraryDescriptor
 import org.yakindu.sct.generator.core.extensions.LibraryExtensions
+import org.yakindu.sct.generator.core.library.AbstractDefaultFeatureValueProvider
 import org.yakindu.sct.generator.core.library.IDefaultFeatureValueProvider
 import org.yakindu.sct.generator.genmodel.ui.internal.GenmodelActivator
 import org.yakindu.sct.generator.genmodel.validation.SGenJavaValidator
@@ -39,9 +41,6 @@ import org.yakindu.sct.model.sgen.GeneratorEntry
 import org.yakindu.sct.model.sgen.GeneratorModel
 import org.yakindu.sct.model.sgraph.Statechart
 import org.yakindu.sct.ui.editor.partitioning.DiagramPartitioningUtil
-import org.yakindu.base.expressions.expressions.PrimitiveValueExpression
-import org.yakindu.sct.commons.EmfUriUtil
-import org.yakindu.sct.generator.core.library.AbstractDefaultFeatureValueProvider
 
 /** 
  * @author andreas muelder - Initial contribution and API

--- a/plugins/org.yakindu.sct.model.stext.ui/src/org/yakindu/sct/model/stext/ui/quickfix/EventTriggerCreationCommand.xtend
+++ b/plugins/org.yakindu.sct.model.stext.ui/src/org/yakindu/sct/model/stext/ui/quickfix/EventTriggerCreationCommand.xtend
@@ -1,0 +1,86 @@
+/** 
+ * Copyright (c) 2019 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * itemis AG - initial API and implementation
+ */
+package org.yakindu.sct.model.stext.ui.quickfix
+
+import java.util.Collections
+import org.eclipse.core.runtime.IAdaptable
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.util.EcoreUtil
+import org.eclipse.emf.transaction.util.TransactionUtil
+import org.eclipse.gmf.runtime.common.core.command.CommandResult
+import org.eclipse.gmf.runtime.emf.commands.core.command.AbstractTransactionalCommand
+import org.eclipse.xtext.validation.Issue
+import org.yakindu.base.types.Direction
+import org.yakindu.base.types.TypesFactory
+import org.yakindu.sct.model.sgraph.Statechart
+import org.yakindu.sct.model.stext.stext.InterfaceScope
+import org.yakindu.sct.model.stext.stext.StextFactory
+
+class EventTriggerCreationCommand extends AbstractTransactionalCommand {
+
+	protected extension StextFactory factory = StextFactory.eINSTANCE
+	protected extension TypesFactory typesFactory = TypesFactory.eINSTANCE
+
+	protected EObject contextElement;
+	protected Issue issue;
+	Direction desiredDirection
+
+	new(EObject element, Issue issue, Direction desiredDirection) {
+		super(TransactionUtil.getEditingDomain(element), "Create missing event", Collections.emptyList);
+		this.contextElement = element;
+		this.issue = issue;
+		this.desiredDirection = Direction.IN
+		this.desiredDirection = desiredDirection;
+	}
+
+	def testExec() {
+		return this.doExecuteWithResult(null, null);
+	}
+
+	override protected doExecuteWithResult(IProgressMonitor monitor, IAdaptable info) {
+		try {
+			val createdEvent = createEventDefinition() => [
+				direction = desiredDirection
+				annotationInfo = createAnnotatableElement;
+			]
+			val sc = EcoreUtil.getRootContainer(contextElement) as Statechart
+
+			val eventName = this.issue.data.get(1);
+
+			val parts = eventName.split("\\.");
+			if (parts.size > 1) {
+				val ifaceName = parts.get(0)
+				val eName = parts.get(1)
+				sc.getOrCreateInterface(ifaceName) => [
+					members += createdEvent => [name = eName]
+				]
+			} else {
+				val eName = parts.head
+				sc.getOrCreateInterface(null) => [
+					members += createdEvent => [name = eName]
+				]
+			}
+			return CommandResult.newOKCommandResult();
+		} catch (Exception e) {
+			e.printStackTrace
+			return CommandResult.newErrorCommandResult(e);
+		}
+	}
+
+	protected def InterfaceScope getOrCreateInterface(Statechart sc, String name) {
+		var iface = sc.scopes.filter(InterfaceScope).findFirst[it.name == name]
+		if (iface === null) {
+			iface = createInterfaceScope => [it.name = name]
+			sc.scopes += iface
+		}
+		iface
+	}
+}

--- a/plugins/org.yakindu.sct.model.stext.ui/src/org/yakindu/sct/model/stext/ui/quickfix/STextQuickfixProvider.xtend
+++ b/plugins/org.yakindu.sct.model.stext.ui/src/org/yakindu/sct/model/stext/ui/quickfix/STextQuickfixProvider.xtend
@@ -1,23 +1,95 @@
-/*
- * (c) by committers of YAKINDU */
+/** 
+ * Copyright (c) 2019 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * itemis AG - initial API and implementation
+ */
 package org.yakindu.sct.model.stext.ui.quickfix
 
+import com.google.inject.Inject
+import org.eclipse.core.commands.ExecutionException
+import org.eclipse.core.commands.operations.IOperationHistory
+import org.eclipse.core.commands.operations.IUndoableOperation
+import org.eclipse.core.commands.operations.OperationHistoryFactory
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.gmf.runtime.emf.commands.core.command.AbstractTransactionalCommand
+import org.eclipse.xtext.ui.editor.model.edit.IModificationContext
+import org.eclipse.xtext.ui.editor.quickfix.Fix
+import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionAcceptor
+import org.eclipse.xtext.validation.Issue
 import org.yakindu.base.expressions.ui.quickfix.ExpressionsQuickfixProvider
+import org.yakindu.base.types.Direction
+import org.yakindu.sct.model.sgraph.resource.AbstractSCTResource
+import org.yakindu.sct.model.stext.extensions.STextExtensions
+import org.yakindu.sct.model.stext.validation.STextValidationMessages
 
-/**
- * Custom quickfixes.
- *
- * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#quick-fixes
- */
 class STextQuickfixProvider extends ExpressionsQuickfixProvider {
 
-//	@Fix(STextValidator.INVALID_NAME)
-//	def capitalizeName(Issue issue, IssueResolutionAcceptor acceptor) {
-//		acceptor.accept(issue, 'Capitalize name', 'Capitalize the name.', 'upcase.png') [
-//			context |
-//			val xtextDocument = context.xtextDocument
-//			val firstLetter = xtextDocument.get(issue.offset, 1)
-//			xtextDocument.replace(issue.offset, 1, firstLetter.toUpperCase)
-//		]
-//	}
+	@Inject
+	protected STextExtensions extensions
+
+	def validateIssueData(Issue issue) {
+		if (issue.data.length < 2) {
+			throw new IllegalArgumentException(
+				"issue.data is expected to have two entries: (1) an URI to the statechart resource and (2) the name of the unresolved reference."
+			)
+		}
+	}
+
+	def executeCommand(IUndoableOperation command, Resource resource) {
+		val IOperationHistory history = OperationHistoryFactory.getOperationHistory();
+
+		if (resource instanceof AbstractSCTResource) {
+			var AbstractSCTResource res = resource;
+			try {
+				// --> for specification regeneration (default is false)
+				res.setSerializerEnabled(true);
+				history.execute(command, new NullProgressMonitor(), null);
+			} catch (ExecutionException e) {
+				e.printStackTrace();
+			} finally {
+				res.setSerializerEnabled(false);
+			}
+		} else {
+			throw new Exception();
+		}
+	}
+
+	@Fix(STextValidationMessages.TRIGGER_IS_NO_EVENT)
+	def createInEvent(Issue issue, IssueResolutionAcceptor acceptor) {
+		validateIssueData(issue);
+		acceptor.accept(
+			issue,
+			"create missing in-event",
+			"create missing in-event",
+			null,
+			new UriToContextElementModificationWrapper(issue, [ EObject element, IModificationContext context |
+				val AbstractTransactionalCommand command = new EventTriggerCreationCommand(element, issue,
+					Direction.IN);
+				executeCommand(command, element.eResource)
+			])
+		)
+	}
+
+	@Fix(STextValidationMessages.ERROR_CODE_EXPRESSION_IS_NO_EVENT)
+	def createOutEvent(Issue issue, IssueResolutionAcceptor acceptor) {
+		validateIssueData(issue);
+		acceptor.accept(
+			issue,
+			"create missing out-event",
+			"create missing out-event",
+			null,
+			new UriToContextElementModificationWrapper(issue, [ EObject element, IModificationContext context |
+				val AbstractTransactionalCommand command = new EventTriggerCreationCommand(element, issue,
+					Direction.OUT);
+				executeCommand(command, element.eResource)
+			])
+		)
+	}
+
 }

--- a/plugins/org.yakindu.sct.model.stext.ui/src/org/yakindu/sct/model/stext/ui/quickfix/UriToContextElementModificationWrapper.java
+++ b/plugins/org.yakindu.sct.model.stext.ui/src/org/yakindu/sct/model/stext/ui/quickfix/UriToContextElementModificationWrapper.java
@@ -1,0 +1,43 @@
+/** 
+ * Copyright (c) 2019 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * itemis AG - initial API and implementation
+ */
+package org.yakindu.sct.model.stext.ui.quickfix;
+
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.ui.editor.model.edit.IModification;
+import org.eclipse.xtext.ui.editor.model.edit.IModificationContext;
+import org.eclipse.xtext.ui.editor.model.edit.ISemanticModification;
+import org.eclipse.xtext.validation.Issue;
+import org.yakindu.sct.ui.editor.partitioning.DiagramPartitioningUtil;
+
+public class UriToContextElementModificationWrapper implements IModification {
+
+	private Issue issue;
+	private ISemanticModification semanticModification;
+
+	public UriToContextElementModificationWrapper(Issue issue, ISemanticModification semanticModification) {
+		this.semanticModification = semanticModification;
+		this.issue = issue;
+	}
+
+	@Override
+	public void apply(final IModificationContext context) {
+		String uriString = issue.getData()[0];
+		URI uri = URI.createURI(uriString, true);
+		EObject eObject = DiagramPartitioningUtil.getSharedDomain().getResourceSet().getEObject(uri, true);
+		try {
+			semanticModification.apply(eObject, context);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/resource/StextResource.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/resource/StextResource.java
@@ -34,6 +34,8 @@ import org.yakindu.sct.model.stext.stext.TransitionSpecification;
  */
 public class StextResource extends AbstractSCTResource {
 
+	private static final String NEWLINE = System.getProperty("line.separator");
+
 	public StextResource() {
 		this(null);
 	}
@@ -49,10 +51,15 @@ public class StextResource extends AbstractSCTResource {
 			builder.append("namespace " + statechart.getNamespace());
 		}
 		for (Annotation annotation : statechart.getAnnotations()) {
-			builder.append(serialize(annotation));
+			String serializedAnnotation = serialize(annotation);
+			builder.append(serializedAnnotation);
 		}
 		for (Scope scope : statechart.getScopes()) {
-			builder.append(serialize(scope));
+			String serializedScope = serialize(scope);
+			if (builder.length() > 0 && !(serializedScope.startsWith(NEWLINE))) {
+				builder.append(NEWLINE);
+			}
+			builder.append(serializedScope);
 		}
 		statechart.setSpecification(builder.toString());
 	}

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextValidationMessages.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextValidationMessages.java
@@ -48,6 +48,7 @@ public interface STextValidationMessages {
 	public static final String EXIT_NEVER_USED = "The named exit is not used: ";
 	public static final String TRANSITION_EXIT_SPEC_ON_MULTIPLE_SIBLINGS = "ExitPointSpec can't be used on transition siblings.";
 	public static final String ISSUE_TRANSITION_WITHOUT_TRIGGER = "Missing trigger. Transition is never taken. Use 'oncycle' or 'always' instead.";
+	public static final String ERROR_CODE_EXPRESSION_IS_NO_EVENT = "error_code_expression_invalid_event";
 	public static final String EXITPOINTSPEC_WITH_TRIGGER = "Transitions with an exit point spec does not have a trigger or guard.";
 	public static final String REFERENCE_CONSTANT_BEFORE_DEFINED = "Cannot reference a constant from different scope or before it is defined.";
 	public static final String INTERNAL_DECLARATION_UNUSED = "Internal declaration is not used in statechart.";

--- a/test-plugins/org.yakindu.sct.refactoring.tests/META-INF/MANIFEST.MF
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtext.junit4,
  org.yakindu.sct.model.sexec,
  org.yakindu.sct.test.models,
- org.yakindu.sct.domain.generic.resource
+ org.yakindu.sct.model.stext.test,
+ org.yakindu.sct.model.stext.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.yakindu.sct.refactoring.tests

--- a/test-plugins/org.yakindu.sct.refactoring.tests/src/org/yakindu/sct/refactoring/refactor/AllTests.java
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/src/org/yakindu/sct/refactoring/refactor/AllTests.java
@@ -21,6 +21,8 @@ import org.yakindu.sct.refactoring.refactor.impl.InlineSubdiagramRefactoringTest
 import org.yakindu.sct.refactoring.refactor.impl.RenameRefactoringTest;
 import org.yakindu.sct.refactoring.refactor.impl.UnfoldEntryActionsRefactoringTest;
 import org.yakindu.sct.refactoring.refactor.impl.UnfoldExitActionsRefactoringTest;
+import org.yakindu.sct.refactoring.refactor.quickfix.STextEventRaiseQuickfixTest;
+import org.yakindu.sct.refactoring.refactor.quickfix.STextTriggerQuickfixTest;
 
 /**
  * 
@@ -29,7 +31,10 @@ import org.yakindu.sct.refactoring.refactor.impl.UnfoldExitActionsRefactoringTes
  */
 @RunWith(Suite.class)
 @SuiteClasses({ FoldIncomingActionsRefactoringTest.class,
-		FoldOutgoingActionsRefactoringTest.class, RenameRefactoringTest.class,
+		FoldOutgoingActionsRefactoringTest.class, 
+		RenameRefactoringTest.class,
+		STextTriggerQuickfixTest.class,
+		STextEventRaiseQuickfixTest.class,
 		UnfoldEntryActionsRefactoringTest.class,
 		UnfoldExitActionsRefactoringTest.class,
 		GroupStatesIntoCompositeRefactoringTest.class,

--- a/test-plugins/org.yakindu.sct.refactoring.tests/src/org/yakindu/sct/refactoring/refactor/quickfix/AbstractSTextQuickfixTest.java
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/src/org/yakindu/sct/refactoring/refactor/quickfix/AbstractSTextQuickfixTest.java
@@ -1,0 +1,51 @@
+/** 
+ * Copyright (c) 2019 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * itemis AG - initial API and implementation
+ */
+package org.yakindu.sct.refactoring.refactor.quickfix;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.xtext.junit4.InjectWith;
+import org.eclipse.xtext.junit4.XtextRunner;
+import org.eclipse.xtext.validation.Issue.IssueImpl;
+import org.junit.runner.RunWith;
+import org.yakindu.sct.model.sgraph.Statechart;
+import org.yakindu.sct.model.sgraph.resource.AbstractSCTResource;
+import org.yakindu.sct.model.stext.test.util.STextInjectorProvider;
+import org.yakindu.sct.model.stext.ui.quickfix.EventTriggerCreationCommand;
+import org.yakindu.sct.model.stext.validation.STextValidator;
+import org.yakindu.sct.refactoring.refactor.RefactoringTest;
+
+import com.google.inject.Inject;
+
+@RunWith(XtextRunner.class)
+@InjectWith(STextInjectorProvider.class)
+public class AbstractSTextQuickfixTest extends RefactoringTest {
+
+	@Inject
+	protected STextValidator validator;
+
+	protected Statechart initial;
+	protected Statechart expected;
+
+	protected class TestIssueImpl extends IssueImpl {
+		public TestIssueImpl(String elementName) {
+			this.setData(new String[] { "dummyUri", elementName });
+		}
+	}
+
+	protected void execQuickfix(EventTriggerCreationCommand quickfix) {
+		AbstractSCTResource initialRes = (AbstractSCTResource) initial.eResource();
+		initialRes.setSerializerEnabled(true);
+		assertTrue(quickfix.testExec().getStatus().isOK());
+		initialRes.setSerializerEnabled(false);
+
+		compareStatecharts(initial, expected);
+	}
+}

--- a/test-plugins/org.yakindu.sct.refactoring.tests/src/org/yakindu/sct/refactoring/refactor/quickfix/STextEventRaiseQuickfixTest.java
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/src/org/yakindu/sct/refactoring/refactor/quickfix/STextEventRaiseQuickfixTest.java
@@ -1,0 +1,99 @@
+/** 
+ * Copyright (c) 2019 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * itemis AG - initial API and implementation
+ */
+package org.yakindu.sct.refactoring.refactor.quickfix;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.yakindu.sct.refactoring.test.models.RefactoringTestModels.QUICKFIX;
+
+import org.junit.Test;
+import org.yakindu.base.types.Direction;
+import org.yakindu.sct.model.sgraph.State;
+import org.yakindu.sct.model.sgraph.Transition;
+import org.yakindu.sct.model.stext.ui.quickfix.EventTriggerCreationCommand;
+
+public class STextEventRaiseQuickfixTest extends AbstractSTextQuickfixTest {
+	@Test
+	public void testExistingUnnamnedInterface_InsideTransition() {
+
+		this.initial = models.loadStatechartFromResource(QUICKFIX + "before_eventRaiseInsideTransition.sct");
+		this.expected = models.loadStatechartFromResource(QUICKFIX + "after_eventRaiseInsideTransition.sct");
+
+		State stateA = super.getStateByName(initial, "StateA");
+		assertNotNull("something wrong, statechart has one 'StateA'", stateA);
+		assertEquals(1, stateA.getOutgoingTransitions().size());
+
+		Transition element = stateA.getOutgoingTransitions().get(0);
+		EventTriggerCreationCommand quickfix = new EventTriggerCreationCommand(element, new TestIssueImpl("newEvent"),
+				Direction.OUT);
+
+		execQuickfix(quickfix);
+	}
+
+	@Test
+	public void testExistingUnnamnedInterface() {
+		super.initial = models.loadStatechartFromResource(
+				QUICKFIX + "before_eventRaiseInsideLocalReaction_ExistingUnnamendInterface.sct");
+		super.expected = models.loadStatechartFromResource(
+				QUICKFIX + "after_eventRaiseInsideLocalReaction_ExistingUnnamendInterface.sct");
+
+		State stateA = super.getStateByName(initial, "StateA");
+
+		EventTriggerCreationCommand quickfix = new EventTriggerCreationCommand(stateA, new TestIssueImpl("newEvent"),
+				Direction.OUT);
+
+		execQuickfix(quickfix);
+	}
+
+	@Test
+	public void testMissingUnnamnedInterface() {
+		super.initial = models.loadStatechartFromResource(
+				QUICKFIX + "before_eventRaiseInsideLocalReaction_MissingUnnamnedInterface.sct");
+		super.expected = models.loadStatechartFromResource(
+				QUICKFIX + "after_eventRaiseInsideLocalReaction_MissingUnnamnedInterface.sct");
+
+		State stateA = super.getStateByName(initial, "StateA");
+
+		EventTriggerCreationCommand quickfix = new EventTriggerCreationCommand(stateA, new TestIssueImpl("newEvent"),
+				Direction.OUT);
+
+		execQuickfix(quickfix);
+	}
+
+	@Test
+	public void testFeatureCall_ExistingInterface() {
+		super.initial = models.loadStatechartFromResource(
+				QUICKFIX + "before_eventRaiseInsideLocalReaction_FeatureCall_ExistingInterface.sct");
+		super.expected = models.loadStatechartFromResource(
+				QUICKFIX + "after_eventRaiseInsideLocalReaction_FeatureCall_ExistingInterface.sct");
+
+		State stateA = super.getStateByName(initial, "StateA");
+
+		EventTriggerCreationCommand quickfix = new EventTriggerCreationCommand(stateA, new TestIssueImpl("A.newEvent"),
+				Direction.OUT);
+
+		execQuickfix(quickfix);
+	}
+
+	@Test
+	public void testFeatureCall_MissingInterface() {
+		super.initial = models.loadStatechartFromResource(
+				QUICKFIX + "before_eventRaiseInsideLocalReaction_FeatureCall_MissingInterface.sct");
+		super.expected = models.loadStatechartFromResource(
+				QUICKFIX + "after_eventRaiseInsideLocalReaction_FeatureCall_MissingInterface.sct");
+
+		State stateA = super.getStateByName(initial, "StateA");
+
+		EventTriggerCreationCommand quickfix = new EventTriggerCreationCommand(stateA, new TestIssueImpl("A.newEvent"),
+				Direction.OUT);
+
+		execQuickfix(quickfix);
+	}
+}

--- a/test-plugins/org.yakindu.sct.refactoring.tests/src/org/yakindu/sct/refactoring/refactor/quickfix/STextTriggerQuickfixTest.java
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/src/org/yakindu/sct/refactoring/refactor/quickfix/STextTriggerQuickfixTest.java
@@ -1,0 +1,76 @@
+/** 
+ * Copyright (c) 2019 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * itemis AG - initial API and implementation
+ */
+package org.yakindu.sct.refactoring.refactor.quickfix;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.yakindu.sct.refactoring.test.models.RefactoringTestModels.QUICKFIX;
+
+import org.junit.Test;
+import org.yakindu.base.types.Direction;
+import org.yakindu.sct.model.sgraph.State;
+import org.yakindu.sct.model.sgraph.Transition;
+import org.yakindu.sct.model.stext.ui.quickfix.EventTriggerCreationCommand;
+
+public class STextTriggerQuickfixTest extends AbstractSTextQuickfixTest {
+
+	private Transition retrieveSingleTransition() {
+		State stateA = super.getStateByName(initial, "StateA");
+		assertNotNull("something wrong, statechart has one 'StateA'", stateA);
+		assertEquals(1, stateA.getOutgoingTransitions().size());
+
+		Transition element = stateA.getOutgoingTransitions().get(0);
+		return element;
+	}
+
+	@Test
+	public void testMultipleEventsAsTrigger() {
+		this.initial = models.loadStatechartFromResource(QUICKFIX + "before_multipleTransitionTrigger.sct");
+		this.expected = models.loadStatechartFromResource(QUICKFIX + "after_multipleTransitionTrigger.sct");
+
+		EventTriggerCreationCommand quickfix = new EventTriggerCreationCommand(retrieveSingleTransition(),
+				new TestIssueImpl("newEvent"), Direction.IN);
+
+		execQuickfix(quickfix);
+	}
+
+	@Test
+	public void testCreateEventForExistingUnnamedInterface() {
+		this.initial = models.loadStatechartFromResource(QUICKFIX + "before_eventCreation.sct");
+		this.expected = models.loadStatechartFromResource(QUICKFIX + "after_eventCreation.sct");
+
+		EventTriggerCreationCommand quickfix = new EventTriggerCreationCommand(retrieveSingleTransition(),
+				new TestIssueImpl("a"), Direction.IN);
+
+		execQuickfix(quickfix);
+	}
+
+	@Test
+	public void testCreateEventAndUnnamendInterface() {
+		this.initial = models.loadStatechartFromResource(QUICKFIX + "before_eventAndUnnamedInterfaceCreation.sct");
+		this.expected = models.loadStatechartFromResource(QUICKFIX + "after_eventAndUnnamedInterfaceCreation.sct");
+
+		EventTriggerCreationCommand quickfix = new EventTriggerCreationCommand(retrieveSingleTransition(),
+				new TestIssueImpl("a"), Direction.IN);
+
+		execQuickfix(quickfix);
+	}
+
+	@Test
+	public void testCreateEventForExistingNamedInterface() {
+		this.initial = models.loadStatechartFromResource(QUICKFIX + "before_eventCreationForExistingNamedInterface.sct");
+		this.expected = models.loadStatechartFromResource(QUICKFIX + "after_eventCreationForExistingNamedInterface.sct");
+
+		EventTriggerCreationCommand quickfix = new EventTriggerCreationCommand(retrieveSingleTransition(),
+				new TestIssueImpl("A.e"), Direction.IN);
+
+		execQuickfix(quickfix);
+	}
+}

--- a/test-plugins/org.yakindu.sct.refactoring.tests/src/org/yakindu/sct/refactoring/test/models/RefactoringTestModels.java
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/src/org/yakindu/sct/refactoring/test/models/RefactoringTestModels.java
@@ -28,6 +28,7 @@ public class RefactoringTestModels extends AbstractTestModelsUtil {
 	public static final String UNFOLD_EXIT_ACTIONS = "unfold_exit_action/";
 	public static final String GROUPING_STATES = "grouping_states/";
 	public static final String RENAMING = "renaming/";
+	public static final String QUICKFIX = "quickfix/";
 	public static final String EXTRACT_SUBDIAGRAM = "extract_subdiagram/";
 	public static final String INLINE_SUBDIAGRAM = "inline_subdiagram/";
 

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventAndUnnamedInterfaceCreation.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventAndUnnamedInterfaceCreation.sct
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution &#xA;&#xA;interface: in event a" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw _A153cEC9EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_A153cEC9EemlQtzag8IMuw" specification="a" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="181" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+    <edges xmi:id="_A18TsEC9EemlQtzag8IMuw" type="Transition" element="_A153cEC9EemlQtzag8IMuw" source="_4DCToUC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_A1_-EUC9EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_A1_-EkC9EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_A2AlIEC9EemlQtzag8IMuw" x="37" y="40"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_A18TsUC9EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_A1_-EEC9EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_A18TskC9EemlQtzag8IMuw" points="[27, -24, 27, -24]$[94, -24, 94, -24]$[94, 12, 94, 12]$[27, 12, 27, 12]"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventCreation.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventCreation.sct
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution &#xA;&#xA;interface: in event a" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw _A153cEC9EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_A153cEC9EemlQtzag8IMuw" specification="a" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="181" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+    <edges xmi:id="_A18TsEC9EemlQtzag8IMuw" type="Transition" element="_A153cEC9EemlQtzag8IMuw" source="_4DCToUC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_A1_-EUC9EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_A1_-EkC9EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_A2AlIEC9EemlQtzag8IMuw" x="37" y="40"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_A18TsUC9EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_A1_-EEC9EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_A18TskC9EemlQtzag8IMuw" points="[27, -24, 27, -24]$[94, -24, 94, -24]$[94, 12, 94, 12]$[27, 12, 27, 12]"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventCreationForExistingNamedInterface.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventCreationForExistingNamedInterface.sct
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution &#xA;&#xA;interface A: in event e  " name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw _A153cEC9EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_A153cEC9EemlQtzag8IMuw" specification="A.e  " target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="181" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+    <edges xmi:id="_A18TsEC9EemlQtzag8IMuw" type="Transition" element="_A153cEC9EemlQtzag8IMuw" source="_4DCToUC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_A1_-EUC9EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_A1_-EkC9EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_A2AlIEC9EemlQtzag8IMuw" x="37" y="40"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_A18TsUC9EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_A1_-EEC9EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_A18TskC9EemlQtzag8IMuw" points="[27, -24, 27, -24]$[94, -24, 94, -24]$[94, 12, 94, 12]$[27, 12, 27, 12]"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventRaiseInsideLocalReaction.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventRaiseInsideLocalReaction.sct
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution &#xA;&#xA;interface:&#xA;&#xA;out event newEvent" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="entry / raise newEvent" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw"/>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="301" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventRaiseInsideLocalReaction_ExistingUnnamendInterface.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventRaiseInsideLocalReaction_ExistingUnnamendInterface.sct
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution&#xA; &#xA;&#xA;interface: &#xA;out event newEvent" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="entry / raise newEvent" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw"/>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="277" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventRaiseInsideLocalReaction_FeatureCall_ExistingInterface.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventRaiseInsideLocalReaction_FeatureCall_ExistingInterface.sct
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution&#xA; &#xA;&#xA;interface A: &#xA;out event newEvent" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="entry / raise A.newEvent" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw"/>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="277" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventRaiseInsideLocalReaction_FeatureCall_MissingInterface.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventRaiseInsideLocalReaction_FeatureCall_MissingInterface.sct
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution&#xA;interface A : out event newEvent" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="entry / raise A.newEvent" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw"/>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="48" width="277" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventRaiseInsideLocalReaction_MissingUnnamnedInterface.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventRaiseInsideLocalReaction_MissingUnnamnedInterface.sct
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution&#xA;interface : out event newEvent" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="entry / raise newEvent" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw"/>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="277" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventRaiseInsideTransition.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_eventRaiseInsideTransition.sct
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution &#xA;&#xA;interface:&#xA;&#xA;in event existingEvent&#xA;out event newEvent" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw _A153cEC9EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_A153cEC9EemlQtzag8IMuw" specification="existingEvent / raise newEvent" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="253" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+    <edges xmi:id="_A18TsEC9EemlQtzag8IMuw" type="Transition" element="_A153cEC9EemlQtzag8IMuw" source="_4DCToUC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_A1_-EUC9EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_A1_-EkC9EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_A2AlIEC9EemlQtzag8IMuw" x="50" y="12"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_A18TsUC9EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_A1_-EEC9EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_A18TskC9EemlQtzag8IMuw" points="[27, -24, 27, -24]$[94, -24, 94, -24]$[94, 12, 94, 12]$[27, 12, 27, 12]"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_multipleTransitionTrigger.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/after_multipleTransitionTrigger.sct
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution &#xA;&#xA;interface:&#xA;&#xA;in event b&#xA;in event newEvent" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw _A153cEC9EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_A153cEC9EemlQtzag8IMuw" specification="b,newEvent" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="181" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+    <edges xmi:id="_A18TsEC9EemlQtzag8IMuw" type="Transition" element="_A153cEC9EemlQtzag8IMuw" source="_4DCToUC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_A1_-EUC9EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_A1_-EkC9EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_A2AlIEC9EemlQtzag8IMuw" x="37" y="40"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_A18TsUC9EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_A1_-EEC9EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_A18TskC9EemlQtzag8IMuw" points="[27, -24, 27, -24]$[94, -24, 94, -24]$[94, 12, 94, 12]$[27, 12, 27, 12]"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventAndUnnamedInterfaceCreation.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventAndUnnamedInterfaceCreation.sct
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution " name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw _A153cEC9EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_A153cEC9EemlQtzag8IMuw" specification="a" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="181" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+    <edges xmi:id="_A18TsEC9EemlQtzag8IMuw" type="Transition" element="_A153cEC9EemlQtzag8IMuw" source="_4DCToUC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_A1_-EUC9EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_A1_-EkC9EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_A2AlIEC9EemlQtzag8IMuw" x="37" y="40"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_A18TsUC9EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_A1_-EEC9EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_A18TskC9EemlQtzag8IMuw" points="[27, -24, 27, -24]$[94, -24, 94, -24]$[94, 12, 94, 12]$[27, 12, 27, 12]"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventCreation.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventCreation.sct
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution&#xA;&#xA;interface :" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw _A153cEC9EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_A153cEC9EemlQtzag8IMuw" specification="a" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="181" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+    <edges xmi:id="_A18TsEC9EemlQtzag8IMuw" type="Transition" element="_A153cEC9EemlQtzag8IMuw" source="_4DCToUC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_A1_-EUC9EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_A1_-EkC9EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_A2AlIEC9EemlQtzag8IMuw" x="37" y="40"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_A18TsUC9EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_A1_-EEC9EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_A18TskC9EemlQtzag8IMuw" points="[27, -24, 27, -24]$[94, -24, 94, -24]$[94, 12, 94, 12]$[27, 12, 27, 12]"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventCreationForExistingNamedInterface.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventCreationForExistingNamedInterface.sct
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution&#xA;&#xA;&#xA;interface A:" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw _A153cEC9EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_A153cEC9EemlQtzag8IMuw" specification="A.e  " target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="181" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+    <edges xmi:id="_A18TsEC9EemlQtzag8IMuw" type="Transition" element="_A153cEC9EemlQtzag8IMuw" source="_4DCToUC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_A1_-EUC9EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_A1_-EkC9EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_A2AlIEC9EemlQtzag8IMuw" x="37" y="40"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_A18TsUC9EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_A1_-EEC9EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_A18TskC9EemlQtzag8IMuw" points="[27, -24, 27, -24]$[94, -24, 94, -24]$[94, 12, 94, 12]$[27, 12, 27, 12]"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventRaiseInsideLocalReaction_ExistingUnnamendInterface.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventRaiseInsideLocalReaction_ExistingUnnamendInterface.sct
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution &#xA;&#xA;interface:" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="entry / raise newEvent" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw"/>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="277" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventRaiseInsideLocalReaction_FeatureCall_ExistingInterface.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventRaiseInsideLocalReaction_FeatureCall_ExistingInterface.sct
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution &#xA;&#xA;interface A:" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="entry / raise A.newEvent" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw"/>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="277" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventRaiseInsideLocalReaction_FeatureCall_MissingInterface.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventRaiseInsideLocalReaction_FeatureCall_MissingInterface.sct
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution &#xA;&#xA;" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="entry / raise A.newEvent" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw"/>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="48" width="277" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventRaiseInsideLocalReaction_MissingUnnamnedInterface.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventRaiseInsideLocalReaction_MissingUnnamnedInterface.sct
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution&#xA;&#xA;" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="entry / raise newEvent" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw"/>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="277" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventRaiseInsideTransition.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_eventRaiseInsideTransition.sct
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution &#xA;&#xA;interface:&#xA; &#xA;in event existingEvent" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw _A153cEC9EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_A153cEC9EemlQtzag8IMuw" specification="existingEvent / raise newEvent" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="253" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+    <edges xmi:id="_A18TsEC9EemlQtzag8IMuw" type="Transition" element="_A153cEC9EemlQtzag8IMuw" source="_4DCToUC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_A1_-EUC9EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_A1_-EkC9EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_A2AlIEC9EemlQtzag8IMuw" x="50" y="12"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_A18TsUC9EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_A1_-EEC9EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_A18TskC9EemlQtzag8IMuw" points="[27, -24, 27, -24]$[94, -24, 94, -24]$[94, 12, 94, 12]$[27, 12, 27, 12]"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_multipleTransitionTrigger.sct
+++ b/test-plugins/org.yakindu.sct.refactoring.tests/testmodels/refactoring/quickfix/before_multipleTransitionTrigger.sct
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sgraph="http://www.yakindu.org/sct/sgraph/2.0.0">
+  <sgraph:Statechart xmi:id="_4C5JsEC8EemlQtzag8IMuw" specification="@EventDriven&#xA;@ChildFirstExecution &#xA;&#xA;interface:&#xA;&#xA;in event b" name="default">
+    <regions xmi:id="_4C6-40C8EemlQtzag8IMuw" name="main region">
+      <vertices xsi:type="sgraph:Entry" xmi:id="_4DAecUC8EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_4DDhwUC8EemlQtzag8IMuw" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+      <vertices xsi:type="sgraph:State" xmi:id="_4DBsl0C8EemlQtzag8IMuw" specification="" name="StateA" incomingTransitions="_4DDhwUC8EemlQtzag8IMuw _A153cEC9EemlQtzag8IMuw">
+        <outgoingTransitions xmi:id="_A153cEC9EemlQtzag8IMuw" specification="b,newEvent" target="_4DBsl0C8EemlQtzag8IMuw"/>
+      </vertices>
+    </regions>
+  </sgraph:Statechart>
+  <notation:Diagram xmi:id="_4C6-4EC8EemlQtzag8IMuw" type="org.yakindu.sct.ui.editor.editor.StatechartDiagramEditor" element="_4C5JsEC8EemlQtzag8IMuw" measurementUnit="Pixel">
+    <children xmi:id="_4C9bIEC8EemlQtzag8IMuw" type="Region" element="_4C6-40C8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4C_3YEC8EemlQtzag8IMuw" type="RegionName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4C_3YUC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4C_3YkC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4C_3Y0C8EemlQtzag8IMuw" type="RegionCompartment" fontName="Verdana" lineColor="4210752">
+        <children xmi:id="_4DBFgEC8EemlQtzag8IMuw" type="Entry" element="_4DAecUC8EemlQtzag8IMuw">
+          <children xmi:id="_4DBskEC8EemlQtzag8IMuw" type="BorderItemLabelContainer">
+            <children xsi:type="notation:DecorationNode" xmi:id="_4DBsk0C8EemlQtzag8IMuw" type="BorderItemLabel">
+              <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBslEC8EemlQtzag8IMuw"/>
+              <layoutConstraint xsi:type="notation:Location" xmi:id="_4DBslUC8EemlQtzag8IMuw"/>
+            </children>
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBskUC8EemlQtzag8IMuw" fontName="Verdana" lineColor="4210752"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBskkC8EemlQtzag8IMuw"/>
+          </children>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DBFgUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="0" lineColor="16777215"/>
+          <styles xsi:type="notation:NamedStyle" xmi:id="_4DBFgkC8EemlQtzag8IMuw" name="allowColors"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DBslkC8EemlQtzag8IMuw" x="25" y="19"/>
+        </children>
+        <children xmi:id="_4DCToUC8EemlQtzag8IMuw" type="State" element="_4DBsl0C8EemlQtzag8IMuw">
+          <children xsi:type="notation:DecorationNode" xmi:id="_4DCTpUC8EemlQtzag8IMuw" type="StateName">
+            <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTpkC8EemlQtzag8IMuw"/>
+            <layoutConstraint xsi:type="notation:Location" xmi:id="_4DCTp0C8EemlQtzag8IMuw"/>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6sEC8EemlQtzag8IMuw" type="StateTextCompartment">
+            <children xsi:type="notation:Shape" xmi:id="_4DC6sUC8EemlQtzag8IMuw" type="StateTextCompartmentExpression" fontName="Verdana" lineColor="4210752">
+              <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DC6skC8EemlQtzag8IMuw"/>
+            </children>
+          </children>
+          <children xsi:type="notation:Compartment" xmi:id="_4DC6s0C8EemlQtzag8IMuw" type="StateFigureCompartment"/>
+          <styles xsi:type="notation:ShapeStyle" xmi:id="_4DCTokC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15981773" lineColor="12632256"/>
+          <styles xsi:type="notation:FontStyle" xmi:id="_4DCTo0C8EemlQtzag8IMuw"/>
+          <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4DC6tEC8EemlQtzag8IMuw" name="isHorizontal" booleanValue="true"/>
+          <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DDhwEC8EemlQtzag8IMuw" x="13" y="79"/>
+        </children>
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4C_3ZEC8EemlQtzag8IMuw"/>
+      </children>
+      <styles xsi:type="notation:ShapeStyle" xmi:id="_4C9bIUC8EemlQtzag8IMuw" fontName="Verdana" fillColor="15790320" lineColor="12632256"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DAecEC8EemlQtzag8IMuw" x="60" y="36" width="181" height="277"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_4DFW8EC8EemlQtzag8IMuw" type="StatechartText" fontName="Verdana" lineColor="4210752">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DFW8kC8EemlQtzag8IMuw" type="StatechartName">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DFW80C8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DFW9EC8EemlQtzag8IMuw"/>
+      </children>
+      <children xsi:type="notation:Shape" xmi:id="_4DF-AEC8EemlQtzag8IMuw" type="StatechartTextExpression" fontName="Verdana" lineColor="4210752">
+        <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AUC8EemlQtzag8IMuw"/>
+      </children>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4DF-AkC8EemlQtzag8IMuw" x="10" y="10" width="200" height="400"/>
+    </children>
+    <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4C6-4UC8EemlQtzag8IMuw" name="inlineDefinitionSection"/>
+    <styles xsi:type="notation:DiagramStyle" xmi:id="_4C6-4kC8EemlQtzag8IMuw"/>
+    <edges xmi:id="_4DEv4EC8EemlQtzag8IMuw" type="Transition" element="_4DDhwUC8EemlQtzag8IMuw" source="_4DBFgEC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_4DEv5EC8EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_4DEv5UC8EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_4DEv5kC8EemlQtzag8IMuw" y="10"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_4DEv4UC8EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_4DEv40C8EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4DEv4kC8EemlQtzag8IMuw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-cfwEEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_-P10IEC8EemlQtzag8IMuw" id="(0.5,0.5)"/>
+    </edges>
+    <edges xmi:id="_A18TsEC9EemlQtzag8IMuw" type="Transition" element="_A153cEC9EemlQtzag8IMuw" source="_4DCToUC8EemlQtzag8IMuw" target="_4DCToUC8EemlQtzag8IMuw">
+      <children xsi:type="notation:DecorationNode" xmi:id="_A1_-EUC9EemlQtzag8IMuw" type="TransitionExpression">
+        <styles xsi:type="notation:ShapeStyle" xmi:id="_A1_-EkC9EemlQtzag8IMuw"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_A2AlIEC9EemlQtzag8IMuw" x="37" y="40"/>
+      </children>
+      <styles xsi:type="notation:ConnectorStyle" xmi:id="_A18TsUC9EemlQtzag8IMuw" routing="Rectilinear" lineColor="4210752"/>
+      <styles xsi:type="notation:FontStyle" xmi:id="_A1_-EEC9EemlQtzag8IMuw" fontName="Verdana"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_A18TskC9EemlQtzag8IMuw" points="[27, -24, 27, -24]$[94, -24, 94, -24]$[94, 12, 94, 12]$[27, 12, 27, 12]"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>


### PR DESCRIPTION
Also, also a serializer bug has been fixed, which only occoured while
testing the SText Quickfixes. Given a Definition-Section containing only
the default annotations, the quickfix for creating both the event and
its corresponding unnamned interface would eat up all spaces between the
Annotations and the newly created interface.

That caused syntactic failures, as the Annotation and the interface
could not be correctly parsed anymore - no whitespace was between the
keywords.