### PR TITLE
Improve tree shortener fault tolerance

### DIFF
--- a/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/naming/tree/TreeStringShortener.xtend
+++ b/plugins/org.yakindu.sct.model.sexec/src/org/yakindu/sct/model/sexec/naming/tree/TreeStringShortener.xtend
@@ -40,6 +40,9 @@ class TreeStringShortener implements IStringShortener {
 	}
 
 	override addString(List<String> s, Object token) {
+		if(originalStrings.keySet.filter[it != token].map[originalStrings.get(it).join("")].exists[it == s.join("")]) {
+			throw new IllegalArgumentException("String is duplicate: " + s.join("."))
+		}
 		validState = false
 		originalStrings.put(token, s)
 	}


### PR DESCRIPTION
Catches a case where strings could be put twice into the string shortener, introducing a bug where all "`react"`-functions had the same name.