### PR TITLE
Set travis build distro to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-sudo: false
 language: java
-dist: precise
+dist: trusty
 jdk: 
  - oraclejdk8
 addons:


### PR DESCRIPTION
Precise has been long deprecated, everything works the same with trusty. Plus maven output with colors, so that's cool.