### PR TITLE
move DomainActivator back to UI dependent plugin

### DIFF
--- a/plugins/org.yakindu.sct.domain/META-INF/MANIFEST.MF
+++ b/plugins/org.yakindu.sct.domain/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.yakindu.sct.domain,
  org.yakindu.sct.domain.extension,
- org.yakindu.sct.domain.extension.impl
+ org.yakindu.sct.domain.extension.impl,
+ org.yakindu.sct.domain.validation
 Bundle-ClassPath: .
 Automatic-Module-Name: org.yakindu.sct.domain

--- a/plugins/org.yakindu.sct.domain/src/org/yakindu/sct/domain/DomainActivator.java
+++ b/plugins/org.yakindu.sct.domain/src/org/yakindu/sct/domain/DomainActivator.java
@@ -10,11 +10,8 @@
 */
 package org.yakindu.sct.domain;
 
-import org.eclipse.emf.ecore.EValidator;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
-import org.yakindu.sct.domain.validation.DomainValidator;
-import org.yakindu.sct.model.sgraph.SGraphPackage;
 
 public class DomainActivator implements BundleActivator {
 
@@ -26,8 +23,6 @@ public class DomainActivator implements BundleActivator {
 
 	public void start(BundleContext bundleContext) throws Exception {
 		DomainActivator.context = bundleContext;
-		
-		EValidator.Registry.INSTANCE.put(SGraphPackage.eINSTANCE, new DomainValidator());
 	}
 
 	public void stop(BundleContext bundleContext) throws Exception {

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/DiagramActivator.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/DiagramActivator.java
@@ -10,9 +10,12 @@
  */
 package org.yakindu.sct.ui.editor;
 
+import org.eclipse.emf.ecore.EValidator;
 import org.eclipse.gmf.runtime.diagram.core.preferences.PreferencesHint;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
+import org.yakindu.sct.domain.validation.DomainValidator;
+import org.yakindu.sct.model.sgraph.SGraphPackage;
 
 /**
  * 
@@ -37,6 +40,7 @@ public class DiagramActivator extends AbstractUIPlugin {
 		super.start(context);
 		plugin = this;
 		PreferencesHint.registerPreferenceStore(DIAGRAM_PREFERENCES_HINT, getPreferenceStore());
+		EValidator.Registry.INSTANCE.put(SGraphPackage.eINSTANCE, new DomainValidator());
 	}
 
 	@Override


### PR DESCRIPTION
Caused by: java.lang.IllegalStateException: The instance data location
has not been specified yet.

is thrown otherwise when installed via update manager