### PR TITLE
For composite slots, return the slot instead of its value (which is u…

### DIFF
--- a/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/DefaultExpressionInterpreter.xtend
+++ b/plugins/org.yakindu.base.expressions.interpreter/src/org/yakindu/base/expressions/interpreter/DefaultExpressionInterpreter.xtend
@@ -339,6 +339,14 @@ class DefaultExpressionInterpreter extends AbstractExpressionInterpreter impleme
 		return slot.value
 	}
 	
+	def dispatch doExecute(Operation feature, CompositeSlot slot, ArgumentExpression exp) {
+		val executor = operationExecutors.findFirst[canExecute(exp)]
+		if (executor !== null) {
+			return executor.executeOperation(exp)
+		}
+		return slot
+	}
+	
 	def dispatch doExecute(Enumerator feature, Void slot, ArgumentExpression exp) {
 		new Long(feature.literalValue)
 	}


### PR DESCRIPTION
…sually null)

Fix #2797  