### PR TITLE
performance improvements for property page to avoid lag on first drop

### DIFF
--- a/plugins/org.yakindu.base.xtext.utils.jface/src/org/yakindu/base/xtext/utils/jface/viewers/StyledTextXtextAdapter.java
+++ b/plugins/org.yakindu.base.xtext.utils.jface/src/org/yakindu/base/xtext/utils/jface/viewers/StyledTextXtextAdapter.java
@@ -121,6 +121,10 @@ public class StyledTextXtextAdapter {
 	}
 
 	public void adapt(StyledText styledText) {
+		adapt(styledText, true);
+	}
+
+	public void adapt(StyledText styledText, boolean decorate) {
 		this.styledText = styledText;
 
 		// perform initialization of fake resource context
@@ -170,8 +174,10 @@ public class StyledTextXtextAdapter {
 		IFocusService service = (IFocusService) PlatformUI.getWorkbench().getService(IFocusService.class);
 		service.addFocusTracker(styledText, StyledText.class.getCanonicalName());
 
-		// add JDT Style code completion hint decoration
-		this.decoration = createContentAssistDecoration(styledText);
+		if (decorate) {
+			// add JDT Style code completion hint decoration
+			this.decoration = createContentAssistDecoration(styledText);
+		}
 
 		initSelectionProvider();
 	}
@@ -240,9 +246,8 @@ public class StyledTextXtextAdapter {
 	}
 
 	/**
-	 * Creates decoration support for the sourceViewer. code is entirely copied
-	 * from {@link XtextEditor} and its super class
-	 * {@link AbstractDecoratedTextEditor}.
+	 * Creates decoration support for the sourceViewer. code is entirely copied from
+	 * {@link XtextEditor} and its super class {@link AbstractDecoratedTextEditor}.
 	 *
 	 */
 	protected void configureSourceViewerDecorationSupport(SourceViewerDecorationSupport support) {
@@ -418,7 +423,7 @@ public class StyledTextXtextAdapter {
 			}
 
 			text.setSelection(text.getCaretOffset());
-			
+
 		}
 
 		protected void setIgnoreNextFocusLost(boolean b) {

--- a/plugins/org.yakindu.base.xtext.utils.jface/src/org/yakindu/base/xtext/utils/jface/viewers/context/XtextFakeResourceContext.java
+++ b/plugins/org.yakindu.base.xtext.utils.jface/src/org/yakindu/base/xtext/utils/jface/viewers/context/XtextFakeResourceContext.java
@@ -21,12 +21,13 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtext.Constants;
 import org.eclipse.xtext.resource.XtextResource;
-import org.eclipse.xtext.ui.resource.IResourceSetProvider;
+import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.util.StringInputStream;
 import org.yakindu.base.xtext.utils.jface.viewers.util.ActiveEditorTracker;
 
 import com.google.inject.Inject;
 import com.google.inject.Injector;
+import com.google.inject.Provider;
 import com.google.inject.name.Named;
 
 /**
@@ -39,7 +40,7 @@ import com.google.inject.name.Named;
 public class XtextFakeResourceContext {
 
 	@Inject
-	private IResourceSetProvider resourceSetProvider;
+	private Provider<XtextResourceSet> resourceSetProvider;
 	private ResourceSet fakeResourceSet;
 	@Inject
 	private XtextResource fakeResource;
@@ -75,7 +76,7 @@ public class XtextFakeResourceContext {
 	}
 
 	protected void createXtextFakeResourceSet() {
-		fakeResourceSet = resourceSetProvider.get(getActiveProject());
+		fakeResourceSet = resourceSetProvider.get();
 	}
 
 	protected void initXtextFakeResource() {

--- a/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/propertysheets/AbstractEditorPropertySection.java
+++ b/plugins/org.yakindu.sct.ui.editor/src/org/yakindu/sct/ui/editor/propertysheets/AbstractEditorPropertySection.java
@@ -130,7 +130,7 @@ public abstract class AbstractEditorPropertySection extends AbstractModelerPrope
 		final StyledTextXtextAdapter xtextAdapter = new StyledTextXtextAdapter(injector);
 		xtextAdapter.getFakeResourceContext().getFakeResource().eAdapters()
 				.add(new ContextElementAdapter(getEObject()));
-		xtextAdapter.adapt((StyledText) styledText);
+		xtextAdapter.adapt((StyledText) styledText, false);
 
 		initContextMenu(styledText);
 


### PR DESCRIPTION
 - remove decorator, slow native painting
 - do not use ResourceSetProvider (> 100 ms to init project with java
details that are not used anyway)