### PR TITLE
Issue 2856

### DIFF
--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextValidationMessages.java
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextValidationMessages.java
@@ -55,6 +55,7 @@ public interface STextValidationMessages {
 	public static final String IMPORT_NOT_RESOLVED_MSG = "Import '%s' cannot be resolved.";
 	public static final String IMPORT_NOT_RESOLVED_CODE = "ImportNotResolved";
 	public static final String DUPLICATE_IMPORT = "Duplicate import '%s'.";
+	public static final String OTHER_DOMAIN_FOR_IMPORT = "The statement 'import' is not intended for use in the default domain. Please change the domain.";
 	public static final String CONTRADICTORY_ANNOTATIONS = "Some annotations (%s) have contradictory effects.";
 	public static final String BAD_EVENT_NAMES = "'%s' is already used as name of an internal event.";
 	public static final String SYNC_OUTGOING_TRIGGER = "Triggers and guards on a synchronization's outgoing transitions will be ignored.";

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextValidator.xtend
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextValidator.xtend
@@ -776,10 +776,10 @@ class STextValidator extends AbstractSTextValidator implements STextValidationMe
 			}
 		}
 	}
-	@Check()
+    @Check()
 	def void checkIfDomainAllowsForImport(ImportScope importScope){
-		var defaultDomain = "org.yakindu.domain.default"
-		var Statechart statechart=utils.getStatechart(importScope)
+		var Statechart statechart = utils.getStatechart(importScope)
+		var defaultDomain = BasePackage.Literals.DOMAIN_ELEMENT__DOMAIN_ID.getDefaultValueLiteral()
 		if ((statechart !== null) && statechart.getDomainID().equals(defaultDomain)) {
 			warning(OTHER_DOMAIN_FOR_IMPORT, importScope, null, -1)
 		}

--- a/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextValidator.xtend
+++ b/plugins/org.yakindu.sct.model.stext/src/org/yakindu/sct/model/stext/validation/STextValidator.xtend
@@ -776,6 +776,14 @@ class STextValidator extends AbstractSTextValidator implements STextValidationMe
 			}
 		}
 	}
+	@Check()
+	def void checkIfDomainAllowsForImport(ImportScope importScope){
+		var defaultDomain = "org.yakindu.domain.default"
+		var Statechart statechart=utils.getStatechart(importScope)
+		if ((statechart !== null) && statechart.getDomainID().equals(defaultDomain)) {
+			warning(OTHER_DOMAIN_FOR_IMPORT, importScope, null, -1)
+		}
+	}
 	
 	@Check(CheckType.FAST)
 	def void checkOnlyOneEntryPointSpecIsUsed(Transition transition) {

--- a/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/validation/STextValidatorTest.java
+++ b/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/validation/STextValidatorTest.java
@@ -868,6 +868,13 @@ public class STextValidatorTest extends AbstractSTextValidationTest implements S
 		validationResult
 		.assertErrorContains(String.format(STextValidationMessages.IMPORT_NOT_RESOLVED_MSG, "does.not.exist"));
 	}
+	@Test
+	public void checkIfDomainAllowsForImport() {
+		Scope context = (Scope) parseExpression("import:", ImportScope.class.getSimpleName());
+		AssertableDiagnostics validationResult = tester.validate(context);
+		validationResult
+		.assertWarningContains(String.format(STextValidationMessages.OTHER_DOMAIN_FOR_IMPORT));
+	}
 	
 	@Test
 	public void checkDuplicateImport() {

--- a/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/validation/STextValidatorTest.java
+++ b/test-plugins/org.yakindu.sct.model.stext.test/src/org/yakindu/sct/model/stext/test/validation/STextValidatorTest.java
@@ -27,11 +27,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 
 import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.Diagnostician;
 import org.eclipse.xtext.junit4.InjectWith;
 import org.eclipse.xtext.junit4.XtextRunner;
 import org.eclipse.xtext.junit4.validation.AssertableDiagnostics;
+import org.eclipse.xtext.junit4.validation.AssertableDiagnostics.DiagnosticPredicate;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +45,7 @@ import org.yakindu.base.types.typesystem.ITypeSystem;
 import org.yakindu.sct.model.sgraph.Choice;
 import org.yakindu.sct.model.sgraph.Entry;
 import org.yakindu.sct.model.sgraph.Exit;
+import org.yakindu.sct.model.sgraph.Reaction;
 import org.yakindu.sct.model.sgraph.Region;
 import org.yakindu.sct.model.sgraph.RegularState;
 import org.yakindu.sct.model.sgraph.Scope;
@@ -863,17 +866,19 @@ public class STextValidatorTest extends AbstractSTextValidationTest implements S
 	
 	@Test
 	public void checkImportExists() {
-		Scope context = (Scope) parseExpression("import: \"does.not.exist\"", ImportScope.class.getSimpleName());
+		String importName = "does.not.exist";
+		Scope context = (Scope) parseExpression("import: \"" + importName + "\"", ImportScope.class.getSimpleName());
 		AssertableDiagnostics validationResult = tester.validate(context);
-		validationResult
-		.assertErrorContains(String.format(STextValidationMessages.IMPORT_NOT_RESOLVED_MSG, "does.not.exist"));
+		DiagnosticPredicate predicate_IMPORT_NOT_RESOLVED_MSG = errorMsg(String.format(STextValidationMessages.IMPORT_NOT_RESOLVED_MSG, importName));
+		DiagnosticPredicate predicate_OTHER_DOMAIN_FOR_IMPORT = warningMsg(STextValidationMessages.OTHER_DOMAIN_FOR_IMPORT);
+		validationResult.assertAll(predicate_IMPORT_NOT_RESOLVED_MSG, predicate_OTHER_DOMAIN_FOR_IMPORT);
 	}
 	@Test
 	public void checkIfDomainAllowsForImport() {
 		Scope context = (Scope) parseExpression("import:", ImportScope.class.getSimpleName());
 		AssertableDiagnostics validationResult = tester.validate(context);
-		validationResult
-		.assertWarningContains(String.format(STextValidationMessages.OTHER_DOMAIN_FOR_IMPORT));
+		DiagnosticPredicate predicate = warningMsg(STextValidationMessages.OTHER_DOMAIN_FOR_IMPORT);
+		validationResult.assertAll(predicate);
 	}
 	
 	@Test


### PR DESCRIPTION
Added the function `void checkIfDomainAllowsForImport(ImportScope importScope)` that checks if the default domain is used and displays an error on `imports`
fixed #2856 