### PR TITLE
remove duplicate bundle from feature

### DIFF
--- a/features/org.yakindu.sct-feature/feature.xml
+++ b/features/org.yakindu.sct-feature/feature.xml
@@ -203,12 +203,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.yakindu.sct.branding"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>
-
-   <plugin
          id="org.yakindu.sct.examples.wizard"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Branding plugin was contained twice in the feature (see line 46).

Signed-off-by: Michael Keppler <michael.keppler@gmx.de>