### PR TITLE
Enhanced getHandle for named & unnamed interfaces over multiple sm

### DIFF
--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/CExpressionsGenerator.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/CExpressionsGenerator.xtend
@@ -171,7 +171,7 @@ class CExpressionsGenerator extends ExpressionsGenerator {
 
 	def dispatch CharSequence code(FeatureCall it, Operation target) {
 		if (target.eContainer instanceof ComplexType) {
-			return '''«target.getFunctionId(owner.featureOrReference)»(«owner.getHandle(scHandle + "->")»«FOR arg : expressions BEFORE ', ' SEPARATOR ', '»«arg.code»«ENDFOR»)'''
+			return '''«target.getFunctionId(owner.featureOrReference)»(«owner.getHandle»«FOR arg : expressions BEFORE ', ' SEPARATOR ', '»«arg.code»«ENDFOR»)'''
 		}
 		'''«it.owner.code».«target.access»(«FOR arg : expressions SEPARATOR ', '»«arg.code»«ENDFOR»)'''
 	}

--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/extensions/Naming.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/extensions/Naming.xtend
@@ -457,18 +457,29 @@ class Naming {
 		return '''«IF state !== null»«state.stateName.asEscapedIdentifier»«ELSE»«statechart.null_state»«ENDIF»'''
 	}
 		
-	def dispatch getHandle(Expression it, String handle) {
+	def dispatch getHandle(Expression it) {
 		'''/*Cannot find handle for Expression: '«it»' */'''
 	}
 	
-	def dispatch CharSequence getHandle(FeatureCall it, String handle) {
-		'''«owner.getHandle(handle)»«feature.access»'''
+	def dispatch CharSequence getHandle(FeatureCall it) {
+		if(feature instanceof VariableDefinition && owner instanceof FeatureCall) {
+			val owner = owner as FeatureCall
+			val ownerOfOwner = owner.owner
+			// named interface
+			if(ownerOfOwner instanceof FeatureCall) {
+				return '''«feature.asGetter»(«ownerOfOwner.getHandle»)'''	
+			}
+			// unnamed interface
+			return '''«feature.asGetter»(«owner.getHandle»)'''
+		}
+		// statechart internal
+		'''«owner.getHandle»«feature.access»'''
 	}
 	
-	def dispatch getHandle(ElementReferenceExpression it, CharSequence handle) {
+	def dispatch getHandle(ElementReferenceExpression it) {
 		val reference = reference
 		if(reference instanceof VariableDefinition) {
-			'''«handle»«reference.scope.instance».«reference.name»'''
+			'''«scHandle»->«reference.scope.instance».«reference.name»'''
 		}
 	}
 	


### PR DESCRIPTION
Now the handle uses getter methods and it's possible to get it over more than two statecharts, independent of its interface names