### PR TITLE
Fix too eager cycle detection in subchart DFS

### DIFF
--- a/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/util/SubchartDFS.java
+++ b/plugins/org.yakindu.sct.model.sgraph/src/org/yakindu/sct/model/sgraph/util/SubchartDFS.java
@@ -63,6 +63,12 @@ public class SubchartDFS extends DFS {
 				.filter(v -> "sct_types".equals(v.getType().eResource().getURI().fileExtension()))
 				.collect(Collectors.toList());
 	}
+	
+	@Override
+	public boolean isVisited(Object element) {
+		// statecharts can be visited again by different reference paths
+		return super.isVisited(element) && getVisitedDepth(element) >= 0;
+	}
 
 }
 


### PR DESCRIPTION
Already visited statechart properties on a different instance path should ne be regarded as cycles