### PR TITLE
Issue 2903 remove gmock

### DIFF
--- a/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/GTestHelper.java
+++ b/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/GTestHelper.java
@@ -216,6 +216,7 @@ public class GTestHelper {
 				//.wPedantic()
 			 	.wAll()				
 			 	.wExtra()
+			 	.wConversion()
 			 	.wError();
 		 if(compiler == Compiler.GCC) {
 			 gTestCommand.wnoUnusedParameter(); // ignore unused parameter flag

--- a/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/GTestHelper.java
+++ b/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/GTestHelper.java
@@ -220,8 +220,6 @@ public class GTestHelper {
 		 if(compiler == Compiler.GCC) {
 			 gTestCommand.wnoUnusedParameter(); // ignore unused parameter flag
 			 gTestCommand.wnoUnusedFunction(); // ignore unused functions flag
-			 
-			 gTestCommand.wConversion(); // TODO: Only activated for C; does currently not work with GMock and Cpp (see #2903)
 		 }
 		return gTestCommand.build();
 	}

--- a/test-plugins/org.yakindu.sct.generator.cpp.test/gtests/ChildFirstOrthogonalReactions/ChildFirstOrthogonalReactionsTest.cc
+++ b/test-plugins/org.yakindu.sct.generator.cpp.test/gtests/ChildFirstOrthogonalReactions/ChildFirstOrthogonalReactionsTest.cc
@@ -4,11 +4,6 @@
 #include "ChildFirstOrthogonalReactions.h"
 #include "sc_runner.h"
 #include "sc_types.h"
-#include "gmock/gmock.h"
-
-using ::testing::AtLeast;
-using ::testing::Return;
-using ::testing::_;
 
 namespace  {
 

--- a/test-plugins/org.yakindu.sct.generator.cpp.test/gtests/ChildFirstTransitionsinSubchart/ChildFirstTransitionsinSubchartTest.cc
+++ b/test-plugins/org.yakindu.sct.generator.cpp.test/gtests/ChildFirstTransitionsinSubchart/ChildFirstTransitionsinSubchartTest.cc
@@ -4,11 +4,6 @@
 #include "ChildFirstTransitionsInSubchart.h"
 #include "sc_runner.h"
 #include "sc_types.h"
-#include "gmock/gmock.h"
-
-using ::testing::AtLeast;
-using ::testing::Return;
-using ::testing::_;
 
 namespace  {
 

--- a/test-plugins/org.yakindu.sct.generator.cpp.test/gtests/OperationsTest/OperationsTest.cc
+++ b/test-plugins/org.yakindu.sct.generator.cpp.test/gtests/OperationsTest/OperationsTest.cc
@@ -4,11 +4,6 @@
 #include "Operations.h"
 #include "sc_runner.h"
 #include "sc_types.h"
-#include "gmock/gmock.h"
-
-using ::testing::AtLeast;
-using ::testing::Return;
-using ::testing::_;
 
 namespace  {
 

--- a/test-plugins/org.yakindu.sct.generator.cpp.test/gtests/ParentFirstOrthogonalReactions/ParentFirstOrthogonalReactionsTest.cc
+++ b/test-plugins/org.yakindu.sct.generator.cpp.test/gtests/ParentFirstOrthogonalReactions/ParentFirstOrthogonalReactionsTest.cc
@@ -4,11 +4,6 @@
 #include "ParentFirstOrthogonalReactions.h"
 #include "sc_runner.h"
 #include "sc_types.h"
-#include "gmock/gmock.h"
-
-using ::testing::AtLeast;
-using ::testing::Return;
-using ::testing::_;
 
 namespace  {
 


### PR DESCRIPTION
fix #2903 

The problem was a warning in the gmock header compiled with GCC >= 7.1

BUT we don't use anything of gmock. There WAS the plan to use the mocking features of gmock, but they've never been used! So, we simply can remove the gmock include, which should be a simple workaround for this problem.

Tests have been regenerated with https://github.com/Yakindu/sctpro/pull/2230