### PR TITLE
Execute timer task after re-scheduling it to ensure periodic task is …

### DIFF
--- a/plugins/org.yakindu.sct.simulation.core/src/org/yakindu/sct/simulation/core/engine/scheduling/DefaultTimeTaskScheduler.java
+++ b/plugins/org.yakindu.sct.simulation.core/src/org/yakindu/sct/simulation/core/engine/scheduling/DefaultTimeTaskScheduler.java
@@ -170,10 +170,10 @@ public class DefaultTimeTaskScheduler implements ITimeTaskScheduler {
 			if (executionTime <= stopTime) {
 				currentTime = task.getNextExecutionTime();
 				task = tasks.poll();
-				task.run();
 				if (task.period > -1) {
 					schedulePeriodicalTask(task, task.period, task.period);
 				}
+				task.run();
 			} else {
 				currentTime = stopTime;
 				processTasks = false;


### PR DESCRIPTION
…properly unscheduled in event-driven case

In event-driven mode, the timer task callback might unschedule the timer task itself, e.g. on a state change, but with the old code, it will be re-scheduled again. This leads to strange behavior for "every" time triggers (see issue #3023). Therefore, we need to run the task after it was re-scheduled, so it can be properly unscheduled by its callback.

Fixes #3023 