### PR TITLE
Clear active launch before clearing the highlighting to avoid re-high…

### DIFF
--- a/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/model/presenter/SCTSourceDisplay.java
+++ b/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/model/presenter/SCTSourceDisplay.java
@@ -180,10 +180,10 @@ public class SCTSourceDisplay implements ISourceDisplay, IDebugEventSetListener,
 		if (source instanceof IDebugTarget) {
 			IDebugTarget target = (IDebugTarget) source;
 			if (activeLaunch == target.getLaunch()) {
+				activeLaunch = null;
 				for (IDynamicNotationHandler current : handler.values()) {
 					current.terminate();
 				}
-				activeLaunch = null;
 				handler.clear();
 			}
 		}


### PR DESCRIPTION
…lighting due to perspective change

As SCTSourceDisplay is a part listener, it gets notified when the perspective changes due to simulation termination. If this notification arrives before activeLaunch is set to null, it will cause a re-highlighting of active states AFTER the highlighting was cleared.

Fix #3022 