### PR TITLE
Split up initialization for ifaces to avoid in warnings (3.5.11)

### DIFF
--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/providers/eventdriven/EventDrivenConstructorProvider.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/providers/eventdriven/EventDrivenConstructorProvider.xtend
@@ -27,7 +27,7 @@ class EventDrivenConstructorProvider extends ConstructorProvider {
 		val ifaceInstances = interfaces.map[instance].toList
 		toInit.replaceAll[ p |
 			if(ifaceInstances.contains(p.key)) {
-				pair(p.key, "this")
+				pair(p.key, "sc_null")
 			} else {
 				p
 			}
@@ -37,4 +37,16 @@ class EventDrivenConstructorProvider extends ConstructorProvider {
 		}
 		toInit
 	}
+	
+	override protected constructorBody(ExecutionFlow it) {
+		var toConstructorBody = super.constructorBody(it)
+		val ifaceInstances = interfaces.map[instance].toList
+		val ifaceInitialization = '''
+			«FOR ifaceInstance : ifaceInstances»
+				«ifaceInstance» = this;
+			«ENDFOR»
+		'''
+		toConstructorBody + ifaceInitialization
+	}
+	
 }

--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/providers/eventdriven/EventDrivenConstructorProvider.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/providers/eventdriven/EventDrivenConstructorProvider.xtend
@@ -43,7 +43,7 @@ class EventDrivenConstructorProvider extends ConstructorProvider {
 		val ifaceInstances = interfaces.map[instance].toList
 		val ifaceInitialization = '''
 			«FOR ifaceInstance : ifaceInstances»
-				«ifaceInstance» = this;
+				this->«ifaceInstance».parent = this;
 			«ENDFOR»
 		'''
 		toConstructorBody + ifaceInitialization


### PR DESCRIPTION
fix #3039  for 3.5.11 release