### PR TITLE
Run C tests with g++ as they are written in C++ (GTest)

### DIFF
--- a/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/CompileGTestCommand.java
+++ b/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/CompileGTestCommand.java
@@ -176,9 +176,7 @@ public class CompileGTestCommand {
 			}
 		}
 		command.add("-lm");
-		command.add("-lstdc++");
 		command.add("-pthread");
-		// command.add("-pg");
 
 		System.out.println(command);
 		return command;

--- a/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/GTestHelper.java
+++ b/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/GTestHelper.java
@@ -65,10 +65,6 @@ public class GTestHelper {
 		public String getCommand() {
 			return this.command;
 		}
-		
-		public void setCommand(String command) {
-			this.command = command;
-		}
 	}
 	
 	private final Object owner;

--- a/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/GTestHelper.java
+++ b/test-plugins/org.yakindu.sct.generator.c.test/src/org/yakindu/sct/generator/c/gtest/GTestHelper.java
@@ -65,6 +65,10 @@ public class GTestHelper {
 		public String getCommand() {
 			return this.command;
 		}
+		
+		public void setCommand(String command) {
+			this.command = command;
+		}
 	}
 	
 	private final Object owner;
@@ -211,7 +215,7 @@ public class GTestHelper {
 		File targetPath = ResourcesPlugin.getWorkspace().getRoot().findMember(getTargetPath()).getLocation().toFile();
 
 		 CompileGTestCommand gTestCommand = new CompileGTestCommand()
-				.compiler(getCompilerCommand())
+				.compiler(Compiler.GPLUSPLUS.command) // always compile tests with g++
 				.program(getFileName(getTestProgram()))
 				.includes(includes)
 				.sources(sourceFiles)


### PR DESCRIPTION
Our C tests are written in C++ (using GTest). We should compile them directly with ``g++`` instead of ``gcc``.

The compiler will be chosen by the file ending. But it seems like there is a difference between which compile flags are reused. The easiest way is using ``g++``.

See:
https://stackoverflow.com/questions/3178342/compiling-a-c-program-with-gcc
