### PR TITLE
Remove duplicate sc_string cast

### DIFF
--- a/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/CppExpressionsGenerator.xtend
+++ b/plugins/org.yakindu.sct.generator.cpp/src/org/yakindu/sct/generator/cpp/CppExpressionsGenerator.xtend
@@ -16,7 +16,6 @@ import org.yakindu.base.expressions.expressions.BoolLiteral
 import org.yakindu.base.expressions.expressions.ElementReferenceExpression
 import org.yakindu.base.expressions.expressions.FeatureCall
 import org.yakindu.base.expressions.expressions.LogicalNotExpression
-import org.yakindu.base.expressions.expressions.StringLiteral
 import org.yakindu.base.types.Expression
 import org.yakindu.base.types.typesystem.ITypeSystem
 import org.yakindu.sct.generator.c.CExpressionsGenerator
@@ -26,8 +25,6 @@ import org.yakindu.sct.model.sexec.naming.INamingService
 import org.yakindu.sct.model.stext.stext.ActiveStateReferenceExpression
 import org.yakindu.sct.model.stext.stext.EventRaisingExpression
 import org.yakindu.sct.model.stext.stext.OperationDefinition
-
-import static org.yakindu.sct.generator.c.CGeneratorConstants.*
 
 class CppExpressionsGenerator extends CExpressionsGenerator {
 
@@ -59,8 +56,6 @@ class CppExpressionsGenerator extends CExpressionsGenerator {
 
 	/* Literals */
 	override dispatch CharSequence code(BoolLiteral it) '''«IF value»true«ELSE»false«ENDIF»'''
-	
-	override dispatch CharSequence code(StringLiteral it) '''(«STRING_TYPE») «super._code(it)»'''
 	
 	/** Don't use bool_true for C++ code */
 	override dispatch CharSequence sc_boolean_code(Expression it) {code}


### PR DESCRIPTION
Remove duplicate cast to sc_string for C++.
Defining a variable ``var x : string = "a"`` results ``iface.x = (sc_string) (sc_string) "a"`` in C++.