### PR TITLE
Use upper case type name as transformed statechart type will be upper…

### DIFF
--- a/plugins/org.yakindu.sct.simulation.core/src/org/yakindu/sct/simulation/core/debugmodel/SCTDebugTarget.java
+++ b/plugins/org.yakindu.sct.simulation.core/src/org/yakindu/sct/simulation/core/debugmodel/SCTDebugTarget.java
@@ -24,6 +24,7 @@ import org.eclipse.debug.core.model.IStep;
 import org.eclipse.debug.core.model.IThread;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.yakindu.base.base.NamedElement;
 import org.yakindu.sct.model.sruntime.ExecutionContext;
 import org.yakindu.sct.simulation.core.engine.IExecutionControl;
@@ -92,7 +93,7 @@ public class SCTDebugTarget extends SCTDebugElement implements IDebugTarget, ISt
 
 	public String getName() throws DebugException {
 		if (context != null) {
-			return context + " : " + element.getName();
+			return context + " : " + StringExtensions.toFirstUpper(element.getName());
 		}
 		return element.getName();
 	}


### PR DESCRIPTION
… case

This fixes the highlighting during the simulation for sub-charts starting with a lower case.