### PR TITLE
Remove MaxPermSize vm argument

### DIFF
--- a/plugins/org.yakindu.base.expressions/GenerateExpressions.mwe2.launch
+++ b/plugins/org.yakindu.base.expressions/GenerateExpressions.mwe2.launch
@@ -14,5 +14,5 @@
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="src/org/yakindu/base/expressions/GenerateExpressions.mwe2"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.yakindu.base.expressions"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx512m -XX:MaxPermSize=256m"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx512m"/>
 </launchConfiguration>

--- a/plugins/org.yakindu.sct.doc.user/src/user-guide/installation.textile
+++ b/plugins/org.yakindu.sct.doc.user/src/user-guide/installation.textile
@@ -116,7 +116,6 @@ plugins/org.eclipse.equinox.launcher.gtk.linux.x86_64_1.1.550.v20170928-1359
 -XX:PermSize=256m
 -XX:+UseParallelGC
 -Xmx3G
--XX:MaxPermSize=256m
 
 bq. *Please note*: Do _not_ attempt to replace all of the contents of your _SCT.ini_ file with the lines above! The specified version numbers have to match your installation, and if you change them, SCT will not be able to start anymore.
 

--- a/plugins/org.yakindu.sct.generator.genmodel/GenerateSGen.mwe2.launch
+++ b/plugins/org.yakindu.sct.generator.genmodel/GenerateSGen.mwe2.launch
@@ -10,5 +10,5 @@
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="src/org/yakindu/sct/generator/genmodel/GenerateSGen.mwe2"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.yakindu.sct.generator.genmodel"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx512m -XX:MaxPermSize=256m"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx512m"/>
 </launchConfiguration>

--- a/plugins/org.yakindu.sct.model.stext/GenerateSText.mwe2.launch
+++ b/plugins/org.yakindu.sct.model.stext/GenerateSText.mwe2.launch
@@ -5,6 +5,6 @@
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="src/org/yakindu/sct/model/stext/GenerateSText.mwe2"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.yakindu.sct.model.stext"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx512m -XX:MaxPermSize=256m"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx512m"/>
 <booleanAttribute key="org.eclipse.jdt.launching.STOP_IN_MAIN" value="false"/>
 </launchConfiguration>

--- a/releng/org.yakindu.sct.releng/StateChartTools.setup
+++ b/releng/org.yakindu.sct.releng/StateChartTools.setup
@@ -21,11 +21,6 @@
       value="2048m"
       vm="true"/>
   <setupTask
-      xsi:type="setup:EclipseIniTask"
-      option="-XX:MaxPermSize"
-      value="256m"
-      vm="true"/>
-  <setupTask
       xsi:type="setup:PreferenceTask"
       key="instance/org.eclipse.jdt.launching/org.eclipse.jdt.launching.PREF_STRICTLY_COMPATIBLE_JRE_NOT_AVAILABLE"
       value="ignore"/>

--- a/test-plugins/org.yakindu.sct.generator.c.test/README
+++ b/test-plugins/org.yakindu.sct.generator.c.test/README
@@ -16,7 +16,7 @@ Please consult the gtest documentation for installation and build instructions (
 
 Running the tests:
 
-The C tests are wrapped by Junit tests. Simply run these as Junit-Plugin tests and make sure that the PermGenSpace is big enough ( -XX:MaxPermSize=256m ).
+The C tests are wrapped by Junit tests. Simply run these as Junit-Plugin tests.
 
 Running as plugin tests is necessary since several resources required for the test are loaded from the plugin bundle.
 

--- a/test-plugins/org.yakindu.sct.generator.c.test/all C generator tests.launch
+++ b/test-plugins/org.yakindu.sct.generator.c.test/all C generator tests.launch
@@ -36,7 +36,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.yakindu.sct.generator.c.test"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=256m"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value=""/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.eclipse.platform.ide"/>
 <booleanAttribute key="run_in_ui_thread" value="true"/>

--- a/test-plugins/org.yakindu.sct.generator.cpp.test/all C++ generator tests.launch
+++ b/test-plugins/org.yakindu.sct.generator.cpp.test/all C++ generator tests.launch
@@ -35,7 +35,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.yakindu.sct.generator.cpp.test"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=256m"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value=""/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.eclipse.platform.ide"/>
 <booleanAttribute key="run_in_ui_thread" value="true"/>


### PR DESCRIPTION
This VM argument is not supported anymore with Java 8 and above. Since
the BREE of all Yakindu SCT bundles is 8, the argument is not needed
anymore in the plugins.

Also remove it from all development related artifacts (test launches,
eclipse.ini in oomph setup), since developers should use a Java 8+
runtime, too.

The most visible difference of this change is: no more JVM warnings when
setting up a new Yakindu SCT Oomph setup (when generating all the model
code via launch configs).