### PR TITLE
Use https in target platforms

### DIFF
--- a/releng/org.yakindu.base.target/2018-09.target
+++ b/releng/org.yakindu.base.target/2018-09.target
@@ -11,33 +11,33 @@
 <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/releases/2018-09"/>
+<repository location="https://download.eclipse.org/releases/2018-09"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.pde.source.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.platform.sdk" version="0.0.0"/>
-<repository location="http://download.eclipse.org/eclipse/updates/4.9"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.9"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.jgit.feature.group" version="4.11.0.201803080745-r"/>
-<repository location="http://download.eclipse.org/egit/updates-4.11/"/>
+<repository location="https://download.eclipse.org/egit/updates-4.11/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
 <unit id="com.google.inject" version="3.0.0.v201605172100"/>
 <unit id="com.google.inject.multibindings" version="3.0.0.v201605172100"/>
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
-<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="de.itemis.xtext.antlr.feature.feature.group" version="2.1.1.v201405091103"/>
 <unit id="de.itemis.xtext.antlr.sdk.feature.group" version="2.1.1.v201405091103"/>
-<repository location="http://download.itemis.com/updates/releases/2.1.1/"/>
+<repository location="https://download.itemis.com/updates/releases/2.1.1/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.compare.diagram.papyrus.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/releases/oxygen/201804111000/"/>
+<repository location="https://download.eclipse.org/releases/oxygen/201804111000/"/>
 </location>
 </locations>
 </target>

--- a/releng/org.yakindu.base.target/2019-12.target
+++ b/releng/org.yakindu.base.target/2019-12.target
@@ -12,33 +12,33 @@
 <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/releases/2019-12"/>
+<repository location="https://download.eclipse.org/releases/2019-12"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.pde.source.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.platform.sdk" version="0.0.0"/>
-<repository location="http://download.eclipse.org/eclipse/updates/4.14"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.14"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.jgit.feature.group" version="4.11.0.201803080745-r"/>
-<repository location="http://download.eclipse.org/egit/updates-4.11/"/>
+<repository location="https://download.eclipse.org/egit/updates-4.11/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
 <unit id="com.google.inject" version="3.0.0.v201605172100"/>
 <unit id="com.google.inject.multibindings" version="3.0.0.v201605172100"/>
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
-<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="de.itemis.xtext.antlr.feature.feature.group" version="2.1.1.v201405091103"/>
 <unit id="de.itemis.xtext.antlr.sdk.feature.group" version="2.1.1.v201405091103"/>
-<repository location="http://download.itemis.com/updates/releases/2.1.1/"/>
+<repository location="https://download.itemis.com/updates/releases/2.1.1/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.compare.diagram.papyrus.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/releases/oxygen/201804111000/"/>
+<repository location="https://download.eclipse.org/releases/oxygen/201804111000/"/>
 </location>
 </locations>
 </target>

--- a/releng/org.yakindu.base.target/Oxygen.target
+++ b/releng/org.yakindu.base.target/Oxygen.target
@@ -3,7 +3,7 @@
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="de.itemis.xtext.antlr.feature.feature.group" version="2.1.1.v201405091103"/>
 <unit id="de.itemis.xtext.antlr.sdk.feature.group" version="2.1.1.v201405091103"/>
-<repository location="http://download.itemis.com/updates/releases/2.1.1/"/>
+<repository location="https://download.itemis.com/updates/releases/2.1.1/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.gson" version="2.2.4.v201311231704"/>
@@ -12,16 +12,16 @@
 <unit id="com.google.inject.multibindings.source" version="3.0.0.v201402270930"/>
 <unit id="com.google.inject.source" version="3.0.0.v201312141243"/>
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
-<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.jgit.feature.group" version="4.5.0.201609210915-r"/>
-<repository location="http://download.eclipse.org/egit/updates-4.5/"/>
+<repository location="https://download.eclipse.org/egit/updates-4.5/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.pde.source.feature.group" version="3.13.2.v20171130-0510"/>
 <unit id="org.eclipse.platform.sdk" version="4.7.2.M20171130-0510"/>
-<repository location="http://download.eclipse.org/eclipse/updates/4.7"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.7"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.cdt.sdk.feature.group" version="9.4.3.201802261533"/>
@@ -36,7 +36,7 @@
 <unit id="org.eclipse.recommenders.news.rcp.feature.feature.group" version="2.5.1.v20180228-0833"/>
 <unit id="org.eclipse.uml2.sdk.feature.group" version="5.3.0.v20170605-1616"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="2.12.0.v20170519-1412"/>
-<repository location="http://download.eclipse.org/releases/oxygen/"/>
+<repository location="https://download.eclipse.org/releases/oxygen/"/>
 </location>
 </locations>
 </target>

--- a/releng/org.yakindu.base.target/Photon.target
+++ b/releng/org.yakindu.base.target/Photon.target
@@ -3,12 +3,12 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.jgit.feature.group" version="4.5.0.201609210915-r"/>
-<repository location="http://download.eclipse.org/egit/updates-4.5/"/>
+<repository location="https://download.eclipse.org/egit/updates-4.5/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="de.itemis.xtext.antlr.feature.feature.group" version="2.1.1.v201405091103"/>
 <unit id="de.itemis.xtext.antlr.sdk.feature.group" version="2.1.1.v201405091103"/>
-<repository location="http://download.itemis.com/updates/releases/2.1.1/"/>
+<repository location="https://download.itemis.com/updates/releases/2.1.1/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.gson" version="2.2.4.v201311231704"/>
@@ -17,12 +17,12 @@
 <unit id="com.google.inject.multibindings.source" version="3.0.0.v201402270930"/>
 <unit id="com.google.inject.source" version="3.0.0.v201312141243"/>
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
-<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.pde.source.feature.group" version="3.13.100.v20180611-0826"/>
 <unit id="org.eclipse.platform.sdk" version="4.8.0.I20180611-0500"/>
-<repository location="http://download.eclipse.org/eclipse/updates/4.8"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.8"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.cdt.sdk.feature.group" version="9.5.0.201806170908"/>
@@ -36,11 +36,11 @@
 <unit id="org.eclipse.recommenders.news.rcp.feature.feature.group" version="2.5.3.v20180609-1554"/>
 <unit id="org.eclipse.uml2.sdk.feature.group" version="5.4.0.v20180604-1153"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="2.14.0.v20180523-0937"/>
-<repository location="http://download.eclipse.org/releases/photon/"/>
+<repository location="https://download.eclipse.org/releases/photon/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.compare.diagram.papyrus.feature.group" version="3.3.2.201709090201"/>
-<repository location="http://download.eclipse.org/releases/oxygen/"/>
+<repository location="https://download.eclipse.org/releases/oxygen/"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
eclipse.org is fully working with https, therefore http should not be
used anymore.

Signed-off-by: Michael Keppler <michael.keppler@gmx.de>