### PR TITLE
Fix "Editor already locked" exception when running multiple simulatio…

### DIFF
--- a/plugins/org.yakindu.base.gmf.runtime/src/org/yakindu/base/gmf/runtime/highlighting/HighlightingSupportAdapter.java
+++ b/plugins/org.yakindu.base.gmf.runtime/src/org/yakindu/base/gmf/runtime/highlighting/HighlightingSupportAdapter.java
@@ -158,12 +158,7 @@ public class HighlightingSupportAdapter implements IHighlightingSupport {
 			throw new IllegalStateException("Editor already locked!");
 		}
 		List<Action> singletonList = new ArrayList<>();
-		singletonList.add(new Action() {
-			@Override
-			public void execute(IHighlightingSupport hs) {
-				lockEditorInternal();
-			}
-		});
+		singletonList.add((support) -> lockEditorInternal());
 		executeAsync(singletonList);
 	}
 
@@ -195,12 +190,7 @@ public class HighlightingSupportAdapter implements IHighlightingSupport {
 			throw new IllegalStateException("Editor not locked!");
 		}
 		List<Action> singletonList = new ArrayList<>();
-		singletonList.add(new Action() {
-			@Override
-			public void execute(IHighlightingSupport hs) {
-				releaseInternal();
-			}
-		});
+		singletonList.add((support) -> releaseInternal());
 		executeAsync(singletonList);
 	}
 
@@ -222,12 +212,9 @@ public class HighlightingSupportAdapter implements IHighlightingSupport {
 			throw new IllegalStateException("Editor not locked!");
 		}
 		List<Action> singletonList = new ArrayList<>();
-		singletonList.add(new Action() {
-			@Override
-			public void execute(IHighlightingSupport hs) {
+		singletonList.add((support) -> {
 				releaseInternal();
 				lockEditorInternal();
-			}
 		});
 		executeAsync(singletonList);
 	}

--- a/plugins/org.yakindu.base.gmf.runtime/src/org/yakindu/base/gmf/runtime/highlighting/HighlightingSupportAdapter.java
+++ b/plugins/org.yakindu.base.gmf.runtime/src/org/yakindu/base/gmf/runtime/highlighting/HighlightingSupportAdapter.java
@@ -190,11 +190,11 @@ public class HighlightingSupportAdapter implements IHighlightingSupport {
 			throw new IllegalStateException("Editor not locked!");
 		}
 		List<Action> singletonList = new ArrayList<>();
-		singletonList.add((support) -> releaseInternal());
+		singletonList.add((support) -> releaseEditorInternal());
 		executeAsync(singletonList);
 	}
 
-	protected void releaseInternal() {
+	protected void releaseEditorInternal() {
 		// restore all elements still being highlighted
 		for (ColorMemento figureState : figureStates.values()) {
 			figureState.restore();
@@ -213,7 +213,7 @@ public class HighlightingSupportAdapter implements IHighlightingSupport {
 		}
 		List<Action> singletonList = new ArrayList<>();
 		singletonList.add((support) -> {
-				releaseInternal();
+				releaseEditorInternal();
 				lockEditorInternal();
 		});
 		executeAsync(singletonList);

--- a/plugins/org.yakindu.base.gmf.runtime/src/org/yakindu/base/gmf/runtime/highlighting/HighlightingSupportAdapter.java
+++ b/plugins/org.yakindu.base.gmf.runtime/src/org/yakindu/base/gmf/runtime/highlighting/HighlightingSupportAdapter.java
@@ -216,6 +216,21 @@ public class HighlightingSupportAdapter implements IHighlightingSupport {
 		object2editPart.clear();
 		locked = false;
 	}
+	
+	public synchronized void releaseAndLockEditor() {
+		if (!locked) {
+			throw new IllegalStateException("Editor not locked!");
+		}
+		List<Action> singletonList = new ArrayList<>();
+		singletonList.add(new Action() {
+			@Override
+			public void execute(IHighlightingSupport hs) {
+				releaseInternal();
+				lockEditorInternal();
+			}
+		});
+		executeAsync(singletonList);
+	}
 
 	public void highlight(List<? extends EObject> semanticElements, HighlightingParameters parameters) {
 		synchronized (semanticElements) {

--- a/plugins/org.yakindu.base.gmf.runtime/src/org/yakindu/base/gmf/runtime/highlighting/IHighlightingSupport.java
+++ b/plugins/org.yakindu.base.gmf.runtime/src/org/yakindu/base/gmf/runtime/highlighting/IHighlightingSupport.java
@@ -27,6 +27,8 @@ public interface IHighlightingSupport {
 	boolean isLocked();
 
 	void releaseEditor();
+	
+	void releaseAndLockEditor();
 
 	void highlight(List<? extends EObject> semanticElement, HighlightingParameters parameters);
 
@@ -90,6 +92,10 @@ public interface IHighlightingSupport {
 
 		@Override
 		public void releaseEditor() {
+		}
+
+		@Override
+		public void releaseAndLockEditor() {
 		}
 
 		@Override

--- a/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/model/presenter/SCTSourceDisplay.java
+++ b/plugins/org.yakindu.sct.simulation.ui/src/org/yakindu/sct/simulation/ui/model/presenter/SCTSourceDisplay.java
@@ -138,9 +138,10 @@ public class SCTSourceDisplay implements ISourceDisplay, IDebugEventSetListener,
 				notationHandler.setHighlightingSupport(support);
 			}
 			if (support.isLocked()) {
-				support.releaseEditor();
+				support.releaseAndLockEditor();
+			} else {
+				support.lockEditor();
 			}
-			support.lockEditor();
 			handler.put(editorPart.getEditorInput(), notationHandler);
 		}
 		return notationHandler;


### PR DESCRIPTION
…ns on same statechart

Since releasing and locking runs asynchronously, they need to be invoked in same async runnable to have a determined execution order.