### PR TITLE
Travis CI: Use lowest target to which we are compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
   - GMOCK_HOME
 matrix:
   include:
-  - env: TARGET=2019-12.target
+  - env: TARGET=Oxygen.target
 before_script:
  - wget https://github.com/google/googletest/archive/release-1.8.0.zip
  - unzip release-1.8.0.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: java
 dist: bionic
 jdk: 
- - openjdk11
+ - openjdk8
 services:
  - xvfb
 addons:

--- a/releng/org.yakindu.base.target/Oxygen.target
+++ b/releng/org.yakindu.base.target/Oxygen.target
@@ -6,13 +6,13 @@
 <repository location="https://download.itemis.com/updates/releases/2.1.1/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="com.google.gson" version="2.2.4.v201311231704"/>
-<unit id="com.google.inject" version="3.0.0.v201312141243"/>
-<unit id="com.google.inject.multibindings" version="3.0.0.v201402270930"/>
+<unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
+<unit id="com.google.inject" version="3.0.0.v201605172100"/>
+<unit id="com.google.inject.multibindings" version="3.0.0.v201605172100"/>
 <unit id="com.google.inject.multibindings.source" version="3.0.0.v201402270930"/>
-<unit id="com.google.inject.source" version="3.0.0.v201312141243"/>
+<unit id="com.google.inject.source" version="3.0.0.v201605172100"/>
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
-<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.jgit.feature.group" version="4.5.0.201609210915-r"/>

--- a/releng/org.yakindu.base.target/Oxygen.target
+++ b/releng/org.yakindu.base.target/Oxygen.target
@@ -9,7 +9,7 @@
 <unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
 <unit id="com.google.inject" version="3.0.0.v201605172100"/>
 <unit id="com.google.inject.multibindings" version="3.0.0.v201605172100"/>
-<unit id="com.google.inject.multibindings.source" version="3.0.0.v201402270930"/>
+<unit id="com.google.inject.multibindings.source" version="3.0.0.v201605172100"/>
 <unit id="com.google.inject.source" version="3.0.0.v201605172100"/>
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
 <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository/"/>

--- a/releng/org.yakindu.base.target/Photon.target
+++ b/releng/org.yakindu.base.target/Photon.target
@@ -11,13 +11,13 @@
 <repository location="https://download.itemis.com/updates/releases/2.1.1/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="com.google.gson" version="2.2.4.v201311231704"/>
-<unit id="com.google.inject" version="3.0.0.v201312141243"/>
-<unit id="com.google.inject.multibindings" version="3.0.0.v201402270930"/>
-<unit id="com.google.inject.multibindings.source" version="3.0.0.v201402270930"/>
-<unit id="com.google.inject.source" version="3.0.0.v201312141243"/>
+<unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
+<unit id="com.google.inject" version="3.0.0.v201605172100"/>
+<unit id="com.google.inject.multibindings" version="3.0.0.v201605172100"/>
+<unit id="com.google.inject.multibindings.source" version="3.0.0.v201605172100"/>
+<unit id="com.google.inject.source" version="3.0.0.v201605172100"/>
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
-<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.pde.source.feature.group" version="3.13.100.v20180611-0826"/>


### PR DESCRIPTION
Currently, we build with 2019-12.target on Travis for the PR builds, but later on, the master will be built with Oxygen.target. And this step can fail when we use constructs that are not available in Oxygen. 