### PR TITLE
Remove SC_UNUSED for several steps

### DIFF
--- a/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/FlowCode.xtend
+++ b/plugins/org.yakindu.sct.generator.c/src/org/yakindu/sct/generator/c/FlowCode.xtend
@@ -219,7 +219,14 @@ class FlowCode {
 	def dispatch requiresHandle(CheckRef e) { true }
 	def dispatch requiresHandle(ElementReferenceExpression e) {(e.reference.isMethod) || (! (e.reference instanceof Parameter)) && (!e.reference.isLocalVariable) && (!e.reference.declaredInHeader) }
 	def dispatch requiresHandle(FeatureCall e) { ! ((e.feature instanceof Parameter) || e.feature.isLocalVariable) }
-
+	def dispatch requiresHandle(ScheduleTimeEvent it) { true }
+	def dispatch requiresHandle(UnscheduleTimeEvent it) { true }
+	def dispatch requiresHandle(EnterState it) { true }
+	def dispatch requiresHandle(ExitState it) { true }
+	def dispatch requiresHandle(HistoryEntry it) { true }
+	def dispatch requiresHandle(SaveHistory it) { true }
+	def dispatch requiresHandle(StateSwitch it) { true }
+	
 	def isLocalVariable(EObject o) {
 		(o instanceof Property) && (o.eContainer instanceof LocalVariableDefinition)	
 	}


### PR DESCRIPTION
These steps implicitly are using the handle. So the ``SC_UNSED`` call is not needed.